### PR TITLE
19 standardize kanban stack heights for easier column movement

### DIFF
--- a/public/assets/js/config.js
+++ b/public/assets/js/config.js
@@ -133,7 +133,7 @@ document.addEventListener('keyup', function(event) {
 
 // Función para igualar la altura de las columnas del Kanban
 function equalizeKanbanColumnsHeight() {
-  const columns = document.querySelectorAll('.tasks');
+  const columns = document.querySelectorAll('.task-list-items');
   if (columns.length === 0) return;
 
   // Primero, resetear las alturas

--- a/public/assets/js/config.js
+++ b/public/assets/js/config.js
@@ -131,3 +131,52 @@ document.addEventListener('keyup', function(event) {
   }
 });
 
+// Función para igualar la altura de las columnas del Kanban
+function equalizeKanbanColumnsHeight() {
+  const columns = document.querySelectorAll('.tasks');
+  if (columns.length === 0) return;
+
+  // Primero, resetear las alturas
+  columns.forEach(column => {
+    column.style.height = 'auto';
+  });
+
+  // Encontrar la altura máxima
+  let maxHeight = 0;
+  columns.forEach(column => {
+    const height = column.offsetHeight;
+    maxHeight = Math.max(maxHeight, height);
+  });
+
+  // Aplicar la altura máxima a todas las columnas
+  columns.forEach(column => {
+    column.style.height = `${maxHeight}px`;
+  });
+}
+
+// Ejecutar cuando el DOM esté listo
+document.addEventListener('DOMContentLoaded', function() {
+  equalizeKanbanColumnsHeight();
+});
+
+// Ejecutar cuando cambie el tamaño de la ventana
+window.addEventListener('resize', function() {
+  equalizeKanbanColumnsHeight();
+});
+
+// Ejecutar cuando se añadan o eliminen tareas
+const observer = new MutationObserver(function(mutations) {
+  equalizeKanbanColumnsHeight();
+});
+
+// Observar cambios en las columnas del Kanban
+document.addEventListener('DOMContentLoaded', function() {
+  const columns = document.querySelectorAll('.task-list-items');
+  columns.forEach(column => {
+    observer.observe(column, {
+      childList: true,
+      subtree: true
+    });
+  });
+});
+


### PR DESCRIPTION
This pull request introduces a new function to equalize the height of Kanban columns and ensures it is executed under various conditions in the `public/assets/js/config.js` file.

Key changes include:

* Added `equalizeKanbanColumnsHeight` function to set all Kanban columns to the same height by finding and applying the maximum column height.
* Ensured the `equalizeKanbanColumnsHeight` function is executed when the DOM is ready by adding an event listener for `DOMContentLoaded`.
* Added a window resize event listener to reapply the column height adjustment when the window size changes.
* Implemented a `MutationObserver` to reapply the column height adjustment when tasks are added or removed from the Kanban columns.
* Set up the `MutationObserver` to observe changes in the Kanban columns when the DOM is ready.