### PR TITLE
Fix quill opening many cards

### DIFF
--- a/public/layouts/task-card.php
+++ b/public/layouts/task-card.php
@@ -537,7 +537,7 @@ function deleteComment(commentId) {
 
 <script type="text/javascript">
 
-var quill;
+var quill = null;
 var assigneesSelect;
 var labelsSelect;
 
@@ -565,21 +565,23 @@ function initializeTaskPage() {
 
 
 	if (document.getElementById('editor')) {
-		quill = new Quill('#editor', {
-			theme: 'snow',
-			readOnly: <?php echo $disabled ? 'true' : 'false'; ?>,
-			modules: {
-				toolbar: [
-					[{ 'header': [1, 2, false] }],
-					['bold', 'italic', 'underline', 'strike'],
-					[{ 'color': [] }, { 'background': [] }],
-					['link', 'blockquote', 'code-block', 'image'],
-					[{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'list': 'check' }],
-					[{ 'indent': '-1' }, { 'indent': '+1' }], // Disminuir y aumentar sangría
-					['clean'],
-				]
-			}
-		});
+		if (quill === null) {
+			quill = new Quill('#editor', {
+				theme: 'snow',
+				readOnly: <?php echo $disabled ? 'true' : 'false'; ?>,
+				modules: {
+					toolbar: [
+						[{ 'header': [1, 2, false] }],
+						['bold', 'italic', 'underline', 'strike'],
+						[{ 'color': [] }, { 'background': [] }],
+						['link', 'blockquote', 'code-block', 'image'],
+						[{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'list': 'check' }],
+						[{ 'indent': '-1' }, { 'indent': '+1' }], // Disminuir y aumentar sangría
+						['clean'],
+					]
+				}
+			});
+		}
 
 	}
 


### PR DESCRIPTION
This pull request includes changes to the `public/layouts/task-card.php` file to ensure proper initialization of the `quill` editor. The main improvements involve setting `quill` to `null` initially and adding a check to initialize it only if it is not already initialized.

Initialization improvements:

* [`public/layouts/task-card.php`](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726L540-R540): Set `quill` to `null` initially to ensure it is properly initialized.
* [`public/layouts/task-card.php`](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726R568): Added a check in `initializeTaskPage` to initialize `quill` only if it is currently `null`. [[1]](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726R568) [[2]](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726R584)