### PR TITLE
Fix permissions on rest elements

### DIFF
--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -593,7 +593,7 @@ class Decker_Tasks {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'mark_user_date_relation' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit' );
+					return current_user_can( 'read' );
 				},
 			)
 		);
@@ -605,7 +605,7 @@ class Decker_Tasks {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'unmark_user_date_relation' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit' );
+					return current_user_can( 'read' );
 				},
 			)
 		);
@@ -617,7 +617,7 @@ class Decker_Tasks {
 				'methods'             => 'PUT',
 				'callback'            => array( $this, 'update_task_stack_and_order' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit' );
+					return current_user_can( 'read' );
 				},
 			)
 		);
@@ -629,7 +629,7 @@ class Decker_Tasks {
 				'methods'             => 'PUT',
 				'callback'            => array( $this, 'update_task_stack_and_order' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit' );
+					return current_user_can( 'read' );
 				},
 			)
 		);
@@ -641,7 +641,7 @@ class Decker_Tasks {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'remove_user_from_task' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit' );
+					return current_user_can( 'read' );
 				},
 			)
 		);
@@ -653,7 +653,7 @@ class Decker_Tasks {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'assign_user_to_task' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit' );
+					return current_user_can( 'read' );
 				},
 			)
 		);
@@ -665,7 +665,7 @@ class Decker_Tasks {
 				'methods'             => 'POST',
 				'callback'            => array( $this, 'archive_task' ),
 				'permission_callback' => function () {
-					return current_user_can( 'edit' );
+					return current_user_can( 'read' );
 				},
 			)
 		);


### PR DESCRIPTION
This pull request includes changes to the `register_rest_routes` method in the `includes/custom-post-types/class-decker-tasks.php` file. The main modification involves updating the permission checks for various REST API routes.

Changes to permission checks:

* Updated the permission callback for `mark_user_date_relation` route to check for `read` capability instead of `edit`.
* Updated the permission callback for `unmark_user_date_relation` route to check for `read` capability instead of `edit`.
* Updated the permission callback for `update_task_stack_and_order` route to check for `read` capability instead of `edit`. [[1]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5L620-R620) [[2]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5L632-R632)
* Updated the permission callback for `remove_user_from_task` route to check for `read` capability instead of `edit`.
* Updated the permission callback for `assign_user_to_task` route to check for `read` capability instead of `edit`.
* Updated the permission callback for `archive_task` route to check for `read` capability instead of `edit`.