### PR TITLE
49 allow pass parameters to url on new tasks like in GitHub

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,10 @@ Decker transforms your WordPress installation into a task management powerhouse 
 - [Development](development.md)
 - [API Reference](api-reference.md)
 
+## Try it Online
+
+You can try Decker without installing it using [WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/main/blueprint.json). This will give you a temporary WordPress installation with Decker pre-installed and configured.
+
 ## Getting Started
 
 1. Install the plugin through WordPress plugin manager or manual upload

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,9 @@
 # Installation Guide
 
+## Try Before Installing
+
+Want to test Decker before installing? Try our demo on [WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/main/blueprint.json). This gives you a temporary WordPress environment with Decker pre-installed and ready to use.
+
 ## System Requirements
 
 - WordPress 5.0 or higher

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -15,13 +15,37 @@ The board is divided into columns representing different stages of task progress
 ### Managing Tasks
 
 #### Creating Tasks
-1. Click the "+" button in any column
-2. Fill in the task details:
-   - Title (required)
-   - Description
-   - Priority level
-   - Due date
-   - Assignee
+
+There are two ways to create tasks:
+
+1. Through the Interface:
+   - Click the "+" button in any column
+   - Fill in the task details:
+     - Title (required)
+     - Description
+     - Priority level
+     - Due date
+     - Assignee
+
+2. Using URL Parameters:
+   You can create pre-filled tasks by using URL parameters. This is useful for integrations or bookmarks.
+   
+   Base URL format:
+   ```
+   /?decker_page=task&type=new&[parameters]
+   ```
+   
+   Available parameters:
+   - title: Task title
+   - description: Task description
+   - board: Board slug identifier
+   - stack: Task status (to-do, in-progress, done)
+   - maximum_priority: Set to 1 for maximum priority
+   
+   Example URL:
+   ```
+   /?decker_page=task&type=new&title=Bug%20Fix&description=Fix%20the%20login%20issue&board=board-1&stack=in-progress&maximum_priority=1
+   ```
 
 #### Priority System
 Decker uses a unique priority system:

--- a/public/layouts/task-card.php
+++ b/public/layouts/task-card.php
@@ -47,7 +47,7 @@ if ( ! defined( 'DECKER_TASK' ) ) {
 }
 
 
-// Initialize variables from URL parameters for new tasks
+// Initialize variables from URL parameters for new tasks.
 $task_id = 0;
 $board_slug = '';
 $initial_title = '';
@@ -56,33 +56,33 @@ $initial_stack = 'to-do';
 $initial_max_priority = false;
 
 if ( isset( $_GET['id'] ) ) {
-    $task_id = intval( $_GET['id'] );
+	$task_id = intval( $_GET['id'] );
 }
 
-// Handle URL parameters for new task creation
-if ( isset( $_GET['type'] ) && $_GET['type'] === 'new' ) {
-    if ( isset( $_GET['title'] ) ) {
-        $initial_title = sanitize_text_field( wp_unslash( $_GET['title'] ) );
-    }
-    if ( isset( $_GET['description'] ) ) {
-        $initial_description = wp_kses( wp_unslash( $_GET['description'] ), Decker::get_allowed_tags() );
-    }
-    if ( isset( $_GET['board'] ) ) {
-        $board_slug = sanitize_text_field( wp_unslash( $_GET['board'] ) );
-    }
-    if ( isset( $_GET['stack'] ) ) {
-        $initial_stack = sanitize_text_field( wp_unslash( $_GET['stack'] ) );
-    }
-    if ( isset( $_GET['maximum_priority'] ) && $_GET['maximum_priority'] === '1' ) {
-        $initial_max_priority = true;
-    }
+// Handle URL parameters for new task creation.
+if ( isset( $_GET['type'] ) && 'new' === $_GET['type'] ) {
+	if ( isset( $_GET['title'] ) ) {
+		$initial_title = sanitize_text_field( wp_unslash( $_GET['title'] ) );
+	}
+	if ( isset( $_GET['description'] ) ) {
+		$initial_description = wp_kses( wp_unslash( $_GET['description'] ), Decker::get_allowed_tags() );
+	}
+	if ( isset( $_GET['board'] ) ) {
+		$board_slug = sanitize_text_field( wp_unslash( $_GET['board'] ) );
+	}
+	if ( isset( $_GET['stack'] ) ) {
+		$initial_stack = sanitize_text_field( wp_unslash( $_GET['stack'] ) );
+	}
+	if ( isset( $_GET['maximum_priority'] ) && '1' === $_GET['maximum_priority'] ) {
+		$initial_max_priority = true;
+	}
 }
 
 $task = new Task( $task_id );
 
-// If no board_slug from new task parameters, try to get it from GET
+// If no board_slug from new task parameters, try to get it from GET.
 if ( empty( $board_slug ) && isset( $_GET['slug'] ) ) {
-    $board_slug = sanitize_text_field( wp_unslash( $_GET['slug'] ) );
+	$board_slug = sanitize_text_field( wp_unslash( $_GET['slug'] ) );
 }
 
 $disabled = false;


### PR DESCRIPTION
This pull request introduces a new feature that allows users to create tasks using URL parameters and includes several documentation updates to reflect this new capability. The most important changes include updates to the user guide, installation guide, and task card layout.

### Documentation Updates:

* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R23-R26): Added a section titled "Try it Online" with a link to a WordPress Playground demo for trying Decker without installation.
* [`docs/installation.md`](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R3-R6): Added a "Try Before Installing" section with a link to the WordPress Playground demo for testing Decker.
* [`docs/user-guide.md`](diffhunk://#diff-971a69e5ae264bfdae535d0c72902cc6f15a559f6d2dc650b78b473f6783c3caL18-R49): Updated the "Creating Tasks" section to include instructions for creating tasks using URL parameters.

### Task Card Layout Enhancements:

* [`public/layouts/task-card.php`](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726R50-R84): Introduced handling of URL parameters for new task creation, initializing variables such as title, description, board slug, stack, and maximum priority from URL parameters. [[1]](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726R50-R84) [[2]](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726L307-R334) [[3]](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726L316-R343) [[4]](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726L389-R418) [[5]](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726L491-R518)