### PR TITLE
Fix priority order

### DIFF
--- a/languages/decker-es_ES.po
+++ b/languages/decker-es_ES.po
@@ -306,7 +306,7 @@ msgstr "Adjuntos"
 
 #: includes/custom-post-types/class-decker-tasks.php:1055
 #: public/app-priority.php:170
-#: public/app-priority.php:384
+#: public/app-priority.php:396
 #: public/app-tasks.php:203
 #: public/layouts/task-card.php:373
 #, fuzzy
@@ -325,7 +325,7 @@ msgstr "Máxima Prioridad"
 #: includes/custom-post-types/class-decker-tasks.php:205
 #: includes/custom-post-types/class-decker-tasks.php:1086
 #: public/app-priority.php:171
-#: public/app-priority.php:385
+#: public/app-priority.php:397
 #: public/app-tasks.php:204
 #: public/layouts/task-card.php:420
 msgid "Stack"
@@ -601,7 +601,7 @@ msgid "Yes"
 msgstr "Sí"
 
 #: public/app-priority.php:154
-#: public/app-priority.php:374
+#: public/app-priority.php:386
 #: public/app-term-manager.php:276
 msgid "Close"
 msgstr "Cerrar"
@@ -611,24 +611,24 @@ msgid "MAX PRIORITY"
 msgstr "MÁXIMA PRIORIDAD"
 
 #: public/app-priority.php:172
-#: public/app-priority.php:386
+#: public/app-priority.php:398
 #: public/layouts/task-card.php:335
 msgid "Title"
 msgstr "Título"
 
-#: public/app-priority.php:191
+#: public/app-priority.php:203
 msgid "No board assigned"
 msgstr "Ningún tablero asignado"
 
-#: public/app-priority.php:332
+#: public/app-priority.php:344
 msgid "No tasks for today."
 msgstr "No hay tareas para hoy."
 
-#: public/app-priority.php:373
+#: public/app-priority.php:385
 msgid "Select tasks to import"
 msgstr "Seleccionar tareas para importar"
 
-#: public/app-priority.php:414
+#: public/app-priority.php:426
 msgid "There are no tasks from previous days to import."
 msgstr "No hay tareas de días anteriores para importar."
 

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -350,7 +350,7 @@ msgstr ""
 #: includes/custom-post-types/class-decker-tasks.php:205
 #: includes/custom-post-types/class-decker-tasks.php:1086
 #: public/app-priority.php:171
-#: public/app-priority.php:385
+#: public/app-priority.php:397
 #: public/app-tasks.php:204
 #: public/layouts/task-card.php:420
 msgid "Stack"
@@ -441,7 +441,7 @@ msgstr ""
 
 #: includes/custom-post-types/class-decker-tasks.php:1055
 #: public/app-priority.php:170
-#: public/app-priority.php:384
+#: public/app-priority.php:396
 #: public/app-tasks.php:203
 #: public/layouts/task-card.php:373
 msgid "Board"
@@ -785,7 +785,7 @@ msgid "Yes"
 msgstr ""
 
 #: public/app-priority.php:154
-#: public/app-priority.php:374
+#: public/app-priority.php:386
 #: public/app-term-manager.php:276
 msgid "Close"
 msgstr ""
@@ -795,24 +795,24 @@ msgid "MAX PRIORITY"
 msgstr ""
 
 #: public/app-priority.php:172
-#: public/app-priority.php:386
+#: public/app-priority.php:398
 #: public/layouts/task-card.php:335
 msgid "Title"
 msgstr ""
 
-#: public/app-priority.php:191
+#: public/app-priority.php:203
 msgid "No board assigned"
 msgstr ""
 
-#: public/app-priority.php:332
+#: public/app-priority.php:344
 msgid "No tasks for today."
 msgstr ""
 
-#: public/app-priority.php:373
+#: public/app-priority.php:385
 msgid "Select tasks to import"
 msgstr ""
 
-#: public/app-priority.php:414
+#: public/app-priority.php:426
 msgid "There are no tasks from previous days to import."
 msgstr ""
 

--- a/public/app-priority.php
+++ b/public/app-priority.php
@@ -187,12 +187,15 @@ if ( ! $has_today_tasks ) {
 									);
 									$tasks = $task_manager->get_tasks( $args );
 
-									// Pre-sort the taks by board name, to avoid flickering on page
-									usort( $tasks, function( $a, $b ) {
-									    $a_board = $a->board ? $a->board->name : '';
-									    $b_board = $b->board ? $b->board->name : '';
-									    return strcmp( $a_board, $b_board );
-									} );
+									// Pre-sort the taks by board name, to avoid flickering on page.
+									usort(
+										$tasks,
+										function ( $a, $b ) {
+											$a_board = $a->board ? $a->board->name : '';
+											$b_board = $b->board ? $b->board->name : '';
+											return strcmp( $a_board, $b_board );
+										}
+									);
 
 
 									foreach ( $tasks as $task ) {

--- a/public/app-priority.php
+++ b/public/app-priority.php
@@ -175,7 +175,7 @@ if ( ! $has_today_tasks ) {
 								</thead>
 								<tbody id="priority-id-table">
 									<?php
-									// Obtener tareas con max_priority.
+									// Get task with max_priority.
 									$args = array(
 										'meta_query' => array(
 											array(
@@ -186,6 +186,15 @@ if ( ! $has_today_tasks ) {
 										),
 									);
 									$tasks = $task_manager->get_tasks( $args );
+
+									// Pre-sort the taks by board name, to avoid flickering on page
+									usort( $tasks, function( $a, $b ) {
+									    $a_board = $a->board ? $a->board->name : '';
+									    $b_board = $b->board ? $b->board->name : '';
+									    return strcmp( $a_board, $b_board );
+									} );
+
+
 									foreach ( $tasks as $task ) {
 
 										$board = __( 'No board assigned', 'decker' );


### PR DESCRIPTION
This pull request includes changes to the `languages/decker-es_ES.po`, `languages/decker.pot`, and `public/app-priority.php` files, focusing on updating translation references and improving task sorting in the priority table. The most important changes are summarized below:

### Translation Reference Updates:

* Updated line references in `languages/decker-es_ES.po` for various translation strings to reflect changes in `public/app-priority.php`. This includes changes to the references for "Adjuntos", "Máxima Prioridad", "Sí", and "MÁXIMA PRIORIDAD". [[1]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL309-R309) [[2]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL328-R328) [[3]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL604-R604) [[4]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL614-R631)

* Updated line references in `languages/decker.pot` for various translation strings to reflect changes in `public/app-priority.php`. This includes changes to the references for "Stack", "Board", "Yes", and "MAX PRIORITY". [[1]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L353-R353) [[2]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L444-R444) [[3]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L788-R788) [[4]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L798-R815)

### Codebase Improvements:

* Changed the comment in `public/app-priority.php` to English for better readability and consistency.

* Added a pre-sorting step for tasks by board name in `public/app-priority.php` to avoid flickering on the page when displaying tasks.