### PR TITLE
73 add card visibility option publicprivate

### DIFF
--- a/includes/class-decker-demo-data.php
+++ b/includes/class-decker-demo-data.php
@@ -156,6 +156,7 @@ class Decker_Demo_Data {
 					$due_date,
 					1,
 					1,
+					false,
 					$assigned_users,
 					$assigned_labels,
 					$creation_date,

--- a/includes/class-decker-email-to-post.php
+++ b/includes/class-decker-email-to-post.php
@@ -370,6 +370,7 @@ class Decker_Email_To_Post {
 			$due_date,
 			$author->ID,
 			$author->ID,
+			false,
 			$assigned_users,
 			array()
 		);

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -1101,6 +1101,8 @@ class Decker_Tasks {
 		$max_priority      = get_post_meta( $post->ID, 'max_priority', true );
 		$stack             = get_post_meta( $post->ID, 'stack', true );
 		$id_nextcloud_card = get_post_meta( $post->ID, 'id_nextcloud_card', true );
+		$responsable       = get_post_meta( $post->ID, 'responsable', true );
+		$hidden            = get_post_meta( $post->ID, 'hidden', true );
 
 		wp_nonce_field( 'save_decker_task', 'decker_task_nonce' );
 
@@ -1125,6 +1127,17 @@ class Decker_Tasks {
 			<label for="id_nextcloud_card"><?php esc_html_e( 'Nextcloud Card ID', 'decker' ); ?></label>
 			<input type="number" name="id_nextcloud_card" value="<?php echo esc_attr( $id_nextcloud_card ); ?>" class="widefat">
 		</p>
+
+		<p>
+			<label for="responsable"><?php esc_html_e( 'Responsable', 'decker' ); ?></label>
+			<input type="number" name="responsable" value="<?php echo esc_attr( $responsable ); ?>" class="widefat">
+		</p>
+
+		<p>
+			<label for="hidden"><?php esc_html_e( 'Hidden', 'decker' ); ?></label>
+			<input type="checkbox" name="hidden" value="1" <?php checked( '1', $hidden ); ?> class="widefat">
+		</p>
+
 		<?php
 	}
 
@@ -1800,6 +1813,8 @@ class Decker_Tasks {
 		$author = isset( $_POST['author'] ) ? intval( wp_unslash( $_POST['author'] ) ) : get_current_user_id();
 		$responsable = isset( $_POST['responsable'] ) ? intval( wp_unslash( $_POST['responsable'] ) ) : $author;
 
+		$hidden = isset( $_POST['hidden'] ) ? boolval( wp_unslash( $_POST['hidden'] ) ) : false;
+
 		// Manejar 'assignees'.
 		$assigned_users = array();
 
@@ -1839,6 +1854,7 @@ class Decker_Tasks {
 			$duedate,
 			$author,
 			$responsable,
+			$hidden,
 			$assigned_users,
 			$labels
 		);
@@ -1883,6 +1899,7 @@ class Decker_Tasks {
 	 * @param DateTime|null $duedate            The due date of the task, or null if not set.
 	 * @param int           $author             The ID of the author of the task.
 	 * @param int           $responsable        The ID of the responsable of the task.
+	 * @param bool          $hidden             Whether the task is hidden in listings.
 	 * @param array         $assigned_users     An array of user IDs assigned to the task.
 	 * @param array         $labels             An array of label IDs associated with the task.
 	 * @param DateTime      $creation_date      The creation date of the task. Default is null.
@@ -1901,6 +1918,7 @@ class Decker_Tasks {
 		?DateTime $duedate,
 		int $author,
 		int $responsable,
+		bool $hidden,
 		array $assigned_users,
 		array $labels,
 		?DateTime $creation_date = null,
@@ -1969,6 +1987,7 @@ class Decker_Tasks {
 			'max_priority'      => $max_priority ? '1' : '0',
 			'assigned_users'    => $assigned_users,
 			'responsable'       => $responsable,
+			'hidden'            => $hidden,
 		);
 
 		// Preparar los datos del post.
@@ -1991,6 +2010,8 @@ class Decker_Tasks {
 		if ( $responsable > 0 ) {
 			$post_data['responsable'] = $responsable;
 		}
+
+		$post_data['hidden'] = $hidden;
 
 		// Determinar si es una actualización o creación.
 		if ( $id > 0 ) {

--- a/includes/models/class-task.php
+++ b/includes/models/class-task.php
@@ -88,6 +88,13 @@ class Task {
 	public WP_User $responsable;
 
 	/**
+	 * Whether the task is hidden in listings.
+	 *
+	 * @var bool
+	 */
+	public bool $hidden = false;
+
+	/**
 	 * The order of the task within its stack.
 	 *
 	 * @var int
@@ -161,6 +168,8 @@ class Task {
 			$responsable_id = isset( $meta['responsable'][0] ) ? (int) $meta['responsable'][0] : $post->post_author;
 
 			$this->responsable  = get_userdata( $responsable_id );
+
+			$this->hidden = isset( $meta['hidden'][0] ) && '1' === $meta['hidden'][0];
 
 			// Use the meta array directly.
 			$this->stack        = isset( $meta['stack'][0] ) ? (string) $meta['stack'][0] : null;
@@ -426,6 +435,9 @@ class Task {
 		if ( $draw_background_color && $this->board && $this->board->color ) {
 			$board_color           = $this->pastelize_color( $this->board->color );
 			$card_background_color = 'style="background-color: ' . esc_attr( $board_color ) . ';"';
+		} elseif ( $this->hidden ) {
+			// For hidden tasks, we set a light gray color.
+			$card_background_color = 'style="background-color: gainsboro;"';
 		}
 
 		?>

--- a/includes/models/class-taskmanager.php
+++ b/includes/models/class-taskmanager.php
@@ -73,6 +73,18 @@ class TaskManager {
 			'orderby'     => array(
 				'max_priority' => 'DESC',
 			),
+			'meta_query'  => array(
+				'relation' => 'OR', // Relationship between the meta query conditions.
+				array(
+					'key'     => 'hidden', // Meta field 'hidden'.
+					'compare' => 'NOT EXISTS', // Exclude tasks that do not have the 'hidden' meta field.
+				),
+				array(
+					'key'     => 'hidden', // Meta field 'hidden'.
+					'value'   => '1', // Value indicating that the task is hidden.
+					'compare' => '!=', // Exclude tasks where 'hidden' is equal to '1'.
+				),
+			),
 		);
 
 		$tasks = $this->get_tasks( $args );

--- a/languages/decker-es_ES.po
+++ b/languages/decker-es_ES.po
@@ -159,8 +159,8 @@ msgstr "Nombre del Nuevo Tablero"
 
 #: includes/custom-post-types/class-decker-boards.php:60
 #: public/app-term-manager.php:116
-#: public/layouts/left-sidebar.php:207
-#: public/layouts/left-sidebar.php:308
+#: public/layouts/left-sidebar.php:212
+#: public/layouts/left-sidebar.php:313
 msgid "Boards"
 msgstr "Tableros"
 
@@ -215,7 +215,7 @@ msgstr "Nombre de la Nueva Etiqueta"
 #: includes/custom-post-types/class-decker-labels.php:60
 #: includes/custom-post-types/class-decker-tasks.php:1077
 #: public/app-term-manager.php:120
-#: public/layouts/left-sidebar.php:294
+#: public/layouts/left-sidebar.php:299
 #: public/layouts/task-card.php:292
 msgid "Labels"
 msgstr "Etiquetas"
@@ -472,19 +472,19 @@ msgstr "Agregar Adjuntos"
 msgid "Select Attachments"
 msgstr "Seleccionar Adjuntos"
 
-#: includes/custom-post-types/class-decker-tasks.php:1932
+#: includes/custom-post-types/class-decker-tasks.php:1931
 msgid "The title is required."
 msgstr "El título es obligatorio."
 
-#: includes/custom-post-types/class-decker-tasks.php:1935
+#: includes/custom-post-types/class-decker-tasks.php:1934
 msgid "The stack is required."
 msgstr "La columna es obligatoria."
 
-#: includes/custom-post-types/class-decker-tasks.php:1938
+#: includes/custom-post-types/class-decker-tasks.php:1937
 msgid "The board is required and must be a positive integer."
 msgstr "El tablero es obligatorio y debe ser un número entero positivo."
 
-#: includes/custom-post-types/class-decker-tasks.php:1944
+#: includes/custom-post-types/class-decker-tasks.php:1943
 msgid "The board does not exist in the decker_board taxonomy."
 msgstr "El tablero no existe en la taxonomía decker_board."
 
@@ -506,13 +506,13 @@ msgstr "Panel de Análisis"
 
 #: public/app-analytics.php:46
 #: public/app-analytics.php:49
-#: public/layouts/left-sidebar.php:246
+#: public/layouts/left-sidebar.php:251
 msgid "Analytics"
 msgstr "Analíticas"
 
 #: public/app-analytics.php:61
 #: public/app-tasks.php:167
-#: public/layouts/left-sidebar.php:149
+#: public/layouts/left-sidebar.php:154
 msgid "Active Tasks"
 msgstr "Tareas Activas"
 
@@ -522,7 +522,7 @@ msgstr "Usuarios Totales"
 
 #: public/app-analytics.php:77
 #: public/app-tasks.php:171
-#: public/layouts/left-sidebar.php:175
+#: public/layouts/left-sidebar.php:180
 msgid "Archived Tasks"
 msgstr "Tareas Archivadas"
 
@@ -646,7 +646,7 @@ msgid "Task Detail"
 msgstr "Detalle de la Tarea"
 
 #: public/app-task-full.php:51
-#: public/layouts/left-sidebar.php:188
+#: public/layouts/left-sidebar.php:193
 msgid "New task"
 msgstr "Nueva tarea"
 
@@ -655,7 +655,7 @@ msgid "Task not found"
 msgstr "Tarea no encontrada"
 
 #: public/app-tasks.php:169
-#: public/layouts/left-sidebar.php:162
+#: public/layouts/left-sidebar.php:167
 msgid "My Tasks"
 msgstr "Mis Tareas"
 
@@ -1114,7 +1114,7 @@ msgstr "¡ADVERTENCIA: ¡Eliminar un tablero es peligroso! Todas las tareas asig
 msgid "Incorrect slug. Deletion cancelled."
 msgstr "Slug incorrecto. Eliminación cancelada."
 
-#: public/layouts/left-sidebar.php:272
+#: public/layouts/left-sidebar.php:277
 msgid "Utilities"
 msgstr "Utilidades"
 
@@ -1224,11 +1224,11 @@ msgstr "No tienes permiso para borrar etiquetas"
 msgid "Loading content. Please wait."
 msgstr "Cargando contenido. Por favor, espere."
 
-#: includes/custom-post-types/class-decker-tasks.php:2071
+#: includes/custom-post-types/class-decker-tasks.php:2070
 msgid "Security check failed."
 msgstr "Error de comprobación."
 
-#: includes/custom-post-types/class-decker-tasks.php:2080
+#: includes/custom-post-types/class-decker-tasks.php:2079
 msgid "Invalid comment data."
 msgstr "Datos de comentario inválidos."
 

--- a/languages/decker-es_ES.po
+++ b/languages/decker-es_ES.po
@@ -314,17 +314,17 @@ msgstr "Adjuntos"
 msgid "Board"
 msgstr "Tablero"
 
-#: includes/custom-post-types/class-decker-tasks.php:1109
+#: includes/custom-post-types/class-decker-tasks.php:1111
 #: public/layouts/task-card.php:254
 msgid "Due Date"
 msgstr "Fecha de Vencimiento"
 
-#: includes/custom-post-types/class-decker-tasks.php:1113
+#: includes/custom-post-types/class-decker-tasks.php:1115
 msgid "Max Priority"
 msgstr "Máxima Prioridad"
 
 #: includes/custom-post-types/class-decker-tasks.php:205
-#: includes/custom-post-types/class-decker-tasks.php:1117
+#: includes/custom-post-types/class-decker-tasks.php:1119
 #: public/app-priority.php:171
 #: public/app-priority.php:403
 #: public/app-tasks.php:204
@@ -332,66 +332,66 @@ msgstr "Máxima Prioridad"
 msgid "Stack"
 msgstr "Columna"
 
-#: includes/custom-post-types/class-decker-tasks.php:1119
+#: includes/custom-post-types/class-decker-tasks.php:1121
 msgid "To-Do"
 msgstr "Por Hacer"
 
-#: includes/custom-post-types/class-decker-tasks.php:1120
+#: includes/custom-post-types/class-decker-tasks.php:1122
 #: public/app-kanban-my.php:100
 #: public/app-kanban.php:150
 #: public/layouts/task-card.php:243
 msgid "In Progress"
 msgstr "En Progreso"
 
-#: includes/custom-post-types/class-decker-tasks.php:1121
+#: includes/custom-post-types/class-decker-tasks.php:1123
 #: public/app-kanban-my.php:115
 #: public/app-kanban.php:165
 #: public/layouts/task-card.php:244
 msgid "Done"
 msgstr "Hecho"
 
-#: includes/custom-post-types/class-decker-tasks.php:1125
+#: includes/custom-post-types/class-decker-tasks.php:1127
 msgid "Nextcloud Card ID"
 msgstr "ID de Tarjeta de Nextcloud"
 
-#: includes/custom-post-types/class-decker-tasks.php:1177
+#: includes/custom-post-types/class-decker-tasks.php:1190
 #: public/layouts/task-card.php:189
 #, fuzzy
 msgid "Select Board"
 msgstr "Buscar Tableros"
 
-#: includes/custom-post-types/class-decker-tasks.php:1228
+#: includes/custom-post-types/class-decker-tasks.php:1241
 msgid "Assign User:"
 msgstr "Asignar Usuario:"
 
-#: includes/custom-post-types/class-decker-tasks.php:1241
+#: includes/custom-post-types/class-decker-tasks.php:1254
 msgid "Assign Date:"
 msgstr "Asignar Fecha:"
 
-#: includes/custom-post-types/class-decker-tasks.php:1247
+#: includes/custom-post-types/class-decker-tasks.php:1260
 msgid "Add Relation"
 msgstr "Agregar Relación"
 
-#: includes/custom-post-types/class-decker-tasks.php:1261
-#: includes/custom-post-types/class-decker-tasks.php:1302
-#: includes/custom-post-types/class-decker-tasks.php:1387
-#: includes/custom-post-types/class-decker-tasks.php:1421
+#: includes/custom-post-types/class-decker-tasks.php:1274
+#: includes/custom-post-types/class-decker-tasks.php:1315
+#: includes/custom-post-types/class-decker-tasks.php:1400
+#: includes/custom-post-types/class-decker-tasks.php:1434
 msgid "Remove"
 msgstr "Eliminar"
 
-#: includes/custom-post-types/class-decker-tasks.php:1283
+#: includes/custom-post-types/class-decker-tasks.php:1296
 msgid "Please select a user and date."
 msgstr "Por favor selecciona un usuario y una fecha."
 
-#: includes/custom-post-types/class-decker-tasks.php:1676
+#: includes/custom-post-types/class-decker-tasks.php:1689
 msgid "Show All Boards"
 msgstr "Mostrar Todos los Tableros"
 
-#: includes/custom-post-types/class-decker-tasks.php:1677
+#: includes/custom-post-types/class-decker-tasks.php:1690
 msgid "Show All Labels"
 msgstr "Mostrar Todas las Etiquetas"
 
-#: includes/custom-post-types/class-decker-tasks.php:1730
+#: includes/custom-post-types/class-decker-tasks.php:1743
 msgid "Status"
 msgstr "Estado"
 
@@ -451,40 +451,40 @@ msgstr "Configuraciones"
 msgid "Go to Decker"
 msgstr "Ir al Decker"
 
-#: includes/custom-post-types/class-decker-tasks.php:1230
+#: includes/custom-post-types/class-decker-tasks.php:1243
 msgid "-- Select User --"
 msgstr "-- Seleccionar Usuario --"
 
-#: includes/custom-post-types/class-decker-tasks.php:1256
+#: includes/custom-post-types/class-decker-tasks.php:1269
 msgid "Unknown User"
 msgstr "Usuario Desconocido"
 
-#: includes/custom-post-types/class-decker-tasks.php:1292
+#: includes/custom-post-types/class-decker-tasks.php:1305
 msgid "This user and date combination already exists."
 msgstr "Esta combinación de usuario y fecha ya existe."
 
-#: includes/custom-post-types/class-decker-tasks.php:1371
-#: includes/custom-post-types/class-decker-tasks.php:1409
+#: includes/custom-post-types/class-decker-tasks.php:1384
+#: includes/custom-post-types/class-decker-tasks.php:1422
 msgid "Add Attachments"
 msgstr "Agregar Adjuntos"
 
-#: includes/custom-post-types/class-decker-tasks.php:1407
+#: includes/custom-post-types/class-decker-tasks.php:1420
 msgid "Select Attachments"
 msgstr "Seleccionar Adjuntos"
 
-#: includes/custom-post-types/class-decker-tasks.php:1913
+#: includes/custom-post-types/class-decker-tasks.php:1932
 msgid "The title is required."
 msgstr "El título es obligatorio."
 
-#: includes/custom-post-types/class-decker-tasks.php:1916
+#: includes/custom-post-types/class-decker-tasks.php:1935
 msgid "The stack is required."
 msgstr "La columna es obligatoria."
 
-#: includes/custom-post-types/class-decker-tasks.php:1919
+#: includes/custom-post-types/class-decker-tasks.php:1938
 msgid "The board is required and must be a positive integer."
 msgstr "El tablero es obligatorio y debe ser un número entero positivo."
 
-#: includes/custom-post-types/class-decker-tasks.php:1925
+#: includes/custom-post-types/class-decker-tasks.php:1944
 msgid "The board does not exist in the decker_board taxonomy."
 msgstr "El tablero no existe en la taxonomía decker_board."
 
@@ -893,7 +893,7 @@ msgstr "Por favor, seleccione una fecha de vencimiento."
 msgid "Assign to"
 msgstr "Asignar a"
 
-#: includes/models/class-task.php:462
+#: includes/models/class-task.php:474
 #: public/layouts/task-card.php:312
 msgid "Comments"
 msgstr "Comentarios"
@@ -918,7 +918,7 @@ msgstr "Seleccionar fecha"
 msgid "Please select a board."
 msgstr "Por favor, seleccione un tablero"
 
-#: public/layouts/task-card.php:490
+#: public/layouts/task-card.php:500
 msgid "Author"
 msgstr "Autor"
 
@@ -927,11 +927,11 @@ msgid "Under construction..."
 msgstr "En construcción..."
 
 #: public/app-term-manager.php:291
-#: public/layouts/task-card.php:506
+#: public/layouts/task-card.php:516
 msgid "Save"
 msgstr "Guardar"
 
-#: public/layouts/task-card.php:509
+#: public/layouts/task-card.php:519
 msgid "Toggle Dropdown"
 msgstr "Alternar Desplegable"
 
@@ -955,51 +955,51 @@ msgstr "Error al subir el archivo adjunto."
 msgid "Are you sure you want to delete this attachment?"
 msgstr "¿Está seguro de que desea eliminar este archivo adjunto?"
 
-#: includes/models/class-task.php:148
+#: includes/models/class-task.php:155
 msgid "Invalid post type."
 msgstr "Tipo de publicación inválido."
 
-#: includes/models/class-task.php:416
+#: includes/models/class-task.php:425
 msgid "🔥"
 msgstr "🔥"
 
-#: includes/models/class-task.php:416
+#: includes/models/class-task.php:425
 msgid "Normal"
 msgstr "Normal"
 
-#: includes/models/class-task.php:418
+#: includes/models/class-task.php:427
 msgid "Undefined date"
 msgstr "Fecha no definida"
 
-#: includes/models/class-task.php:436
+#: includes/models/class-task.php:448
 msgid "Order:"
 msgstr "Orden:"
 
-#: includes/models/class-task.php:515
+#: includes/models/class-task.php:527
 msgid "Edit"
 msgstr "Editar"
 
-#: includes/models/class-task.php:532
+#: includes/models/class-task.php:544
 msgid "Edit in WordPress"
 msgstr "Editar en WordPress"
 
-#: includes/models/class-task.php:539
+#: includes/models/class-task.php:551
 msgid "Archive"
 msgstr "Archivar"
 
-#: includes/models/class-task.php:548
+#: includes/models/class-task.php:560
 msgid "Assign to me"
 msgstr "Asignarme"
 
-#: includes/models/class-task.php:555
+#: includes/models/class-task.php:567
 msgid "Leave"
 msgstr "Abandonar"
 
-#: includes/models/class-task.php:570
+#: includes/models/class-task.php:582
 msgid "Mark for today"
 msgstr "Marcar para hoy"
 
-#: includes/models/class-task.php:576
+#: includes/models/class-task.php:588
 msgid "Unmark for today"
 msgstr "Desmarcar para hoy"
 
@@ -1224,11 +1224,11 @@ msgstr "No tienes permiso para borrar etiquetas"
 msgid "Loading content. Please wait."
 msgstr "Cargando contenido. Por favor, espere."
 
-#: includes/custom-post-types/class-decker-tasks.php:2049
+#: includes/custom-post-types/class-decker-tasks.php:2071
 msgid "Security check failed."
 msgstr "Error de comprobación."
 
-#: includes/custom-post-types/class-decker-tasks.php:2058
+#: includes/custom-post-types/class-decker-tasks.php:2080
 msgid "Invalid comment data."
 msgstr "Datos de comentario inválidos."
 
@@ -1284,6 +1284,7 @@ msgstr "Notificarme cuando se complete una tarea asignada a mí."
 msgid "Notify me when someone comments on a task I am assigned to."
 msgstr "Notificarme cuando alguien comente en una tarea que tengo asignada."
 
+#: includes/custom-post-types/class-decker-tasks.php:1132
 #: public/app-tasks.php:207
 #: public/layouts/task-card.php:233
 msgid "Responsable"
@@ -1301,10 +1302,22 @@ msgstr "Por favor, selecciona un responsable"
 msgid "Information"
 msgstr "Información"
 
-#: public/layouts/task-card.php:470
+#: public/layouts/task-card.php:480
 msgid "Created"
 msgstr "Creado"
 
 #: public/app-term-manager.php:286
 msgid "Only basic HTML formatting is allowed (i, b, em, strong, br)"
 msgstr "Solo se permite formato HTML básico (i, b, em, strong, br)"
+
+#: includes/custom-post-types/class-decker-tasks.php:1137
+msgid "Hidden"
+msgstr "Ocultar"
+
+#: public/layouts/task-card.php:468
+msgid "Hidden task"
+msgstr "Tarea oculta"
+
+#: public/layouts/task-card.php:469
+msgid "(Hidden tasks are not shown in task listings)"
+msgstr "(Las tareas ocultas simplemente no se muestran en los listados)"

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -349,7 +349,7 @@ msgid "Labels"
 msgstr ""
 
 #: includes/custom-post-types/class-decker-tasks.php:205
-#: includes/custom-post-types/class-decker-tasks.php:1117
+#: includes/custom-post-types/class-decker-tasks.php:1119
 #: public/app-priority.php:171
 #: public/app-priority.php:403
 #: public/app-tasks.php:204
@@ -448,119 +448,129 @@ msgstr ""
 msgid "Board"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1109
+#: includes/custom-post-types/class-decker-tasks.php:1111
 #: public/layouts/task-card.php:254
 msgid "Due Date"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1113
+#: includes/custom-post-types/class-decker-tasks.php:1115
 msgid "Max Priority"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1119
+#: includes/custom-post-types/class-decker-tasks.php:1121
 msgid "To-Do"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1120
+#: includes/custom-post-types/class-decker-tasks.php:1122
 #: public/app-kanban-my.php:100
 #: public/app-kanban.php:150
 #: public/layouts/task-card.php:243
 msgid "In Progress"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1121
+#: includes/custom-post-types/class-decker-tasks.php:1123
 #: public/app-kanban-my.php:115
 #: public/app-kanban.php:165
 #: public/layouts/task-card.php:244
 msgid "Done"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1125
+#: includes/custom-post-types/class-decker-tasks.php:1127
 msgid "Nextcloud Card ID"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1177
+#: includes/custom-post-types/class-decker-tasks.php:1132
+#: public/app-tasks.php:207
+#: public/layouts/task-card.php:233
+msgid "Responsable"
+msgstr ""
+
+#: includes/custom-post-types/class-decker-tasks.php:1137
+msgid "Hidden"
+msgstr ""
+
+#: includes/custom-post-types/class-decker-tasks.php:1190
 #: public/layouts/task-card.php:189
 msgid "Select Board"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1228
+#: includes/custom-post-types/class-decker-tasks.php:1241
 msgid "Assign User:"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1230
+#: includes/custom-post-types/class-decker-tasks.php:1243
 msgid "-- Select User --"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1241
+#: includes/custom-post-types/class-decker-tasks.php:1254
 msgid "Assign Date:"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1247
+#: includes/custom-post-types/class-decker-tasks.php:1260
 msgid "Add Relation"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1256
+#: includes/custom-post-types/class-decker-tasks.php:1269
 msgid "Unknown User"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1261
-#: includes/custom-post-types/class-decker-tasks.php:1302
-#: includes/custom-post-types/class-decker-tasks.php:1387
-#: includes/custom-post-types/class-decker-tasks.php:1421
+#: includes/custom-post-types/class-decker-tasks.php:1274
+#: includes/custom-post-types/class-decker-tasks.php:1315
+#: includes/custom-post-types/class-decker-tasks.php:1400
+#: includes/custom-post-types/class-decker-tasks.php:1434
 msgid "Remove"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1283
+#: includes/custom-post-types/class-decker-tasks.php:1296
 msgid "Please select a user and date."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1292
+#: includes/custom-post-types/class-decker-tasks.php:1305
 msgid "This user and date combination already exists."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1371
-#: includes/custom-post-types/class-decker-tasks.php:1409
+#: includes/custom-post-types/class-decker-tasks.php:1384
+#: includes/custom-post-types/class-decker-tasks.php:1422
 msgid "Add Attachments"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1407
+#: includes/custom-post-types/class-decker-tasks.php:1420
 msgid "Select Attachments"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1676
+#: includes/custom-post-types/class-decker-tasks.php:1689
 msgid "Show All Boards"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1677
+#: includes/custom-post-types/class-decker-tasks.php:1690
 msgid "Show All Labels"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1730
+#: includes/custom-post-types/class-decker-tasks.php:1743
 msgid "Status"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1913
+#: includes/custom-post-types/class-decker-tasks.php:1932
 msgid "The title is required."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1916
+#: includes/custom-post-types/class-decker-tasks.php:1935
 msgid "The stack is required."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1919
+#: includes/custom-post-types/class-decker-tasks.php:1938
 msgid "The board is required and must be a positive integer."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1925
+#: includes/custom-post-types/class-decker-tasks.php:1944
 msgid "The board does not exist in the decker_board taxonomy."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:2049
+#: includes/custom-post-types/class-decker-tasks.php:2071
 msgid "Security check failed."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:2058
+#: includes/custom-post-types/class-decker-tasks.php:2080
 msgid "Invalid comment data."
 msgstr ""
 
@@ -632,56 +642,56 @@ msgstr ""
 msgid "Label deleted successfully"
 msgstr ""
 
-#: includes/models/class-task.php:148
+#: includes/models/class-task.php:155
 msgid "Invalid post type."
 msgstr ""
 
-#: includes/models/class-task.php:416
+#: includes/models/class-task.php:425
 msgid "🔥"
 msgstr ""
 
-#: includes/models/class-task.php:416
+#: includes/models/class-task.php:425
 msgid "Normal"
 msgstr ""
 
-#: includes/models/class-task.php:418
+#: includes/models/class-task.php:427
 msgid "Undefined date"
 msgstr ""
 
-#: includes/models/class-task.php:436
+#: includes/models/class-task.php:448
 msgid "Order:"
 msgstr ""
 
-#: includes/models/class-task.php:462
+#: includes/models/class-task.php:474
 #: public/layouts/task-card.php:312
 msgid "Comments"
 msgstr ""
 
-#: includes/models/class-task.php:515
+#: includes/models/class-task.php:527
 msgid "Edit"
 msgstr ""
 
-#: includes/models/class-task.php:532
+#: includes/models/class-task.php:544
 msgid "Edit in WordPress"
 msgstr ""
 
-#: includes/models/class-task.php:539
+#: includes/models/class-task.php:551
 msgid "Archive"
 msgstr ""
 
-#: includes/models/class-task.php:548
+#: includes/models/class-task.php:560
 msgid "Assign to me"
 msgstr ""
 
-#: includes/models/class-task.php:555
+#: includes/models/class-task.php:567
 msgid "Leave"
 msgstr ""
 
-#: includes/models/class-task.php:570
+#: includes/models/class-task.php:582
 msgid "Mark for today"
 msgstr ""
 
-#: includes/models/class-task.php:576
+#: includes/models/class-task.php:588
 msgid "Unmark for today"
 msgstr ""
 
@@ -873,11 +883,6 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
-#: public/app-tasks.php:207
-#: public/layouts/task-card.php:233
-msgid "Responsable"
-msgstr ""
-
 #: public/app-tasks.php:209
 msgid "Remaining Time"
 msgstr ""
@@ -906,7 +911,7 @@ msgid "Only basic HTML formatting is allowed (i, b, em, strong, br)"
 msgstr ""
 
 #: public/app-term-manager.php:291
-#: public/layouts/task-card.php:506
+#: public/layouts/task-card.php:516
 msgid "Save"
 msgstr ""
 
@@ -1271,15 +1276,23 @@ msgstr ""
 msgid "Under construction..."
 msgstr ""
 
-#: public/layouts/task-card.php:470
+#: public/layouts/task-card.php:468
+msgid "Hidden task"
+msgstr ""
+
+#: public/layouts/task-card.php:469
+msgid "(Hidden tasks are not shown in task listings)"
+msgstr ""
+
+#: public/layouts/task-card.php:480
 msgid "Created"
 msgstr ""
 
-#: public/layouts/task-card.php:490
+#: public/layouts/task-card.php:500
 msgid "Author"
 msgstr ""
 
-#: public/layouts/task-card.php:509
+#: public/layouts/task-card.php:519
 msgid "Toggle Dropdown"
 msgstr ""
 

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -287,8 +287,8 @@ msgstr ""
 
 #: includes/custom-post-types/class-decker-boards.php:60
 #: public/app-term-manager.php:116
-#: public/layouts/left-sidebar.php:207
-#: public/layouts/left-sidebar.php:308
+#: public/layouts/left-sidebar.php:212
+#: public/layouts/left-sidebar.php:313
 msgid "Boards"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 #: includes/custom-post-types/class-decker-labels.php:60
 #: includes/custom-post-types/class-decker-tasks.php:1077
 #: public/app-term-manager.php:120
-#: public/layouts/left-sidebar.php:294
+#: public/layouts/left-sidebar.php:299
 #: public/layouts/task-card.php:292
 msgid "Labels"
 msgstr ""
@@ -550,27 +550,27 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1932
+#: includes/custom-post-types/class-decker-tasks.php:1931
 msgid "The title is required."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1935
+#: includes/custom-post-types/class-decker-tasks.php:1934
 msgid "The stack is required."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1938
+#: includes/custom-post-types/class-decker-tasks.php:1937
 msgid "The board is required and must be a positive integer."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:1944
+#: includes/custom-post-types/class-decker-tasks.php:1943
 msgid "The board does not exist in the decker_board taxonomy."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:2071
+#: includes/custom-post-types/class-decker-tasks.php:2070
 msgid "Security check failed."
 msgstr ""
 
-#: includes/custom-post-types/class-decker-tasks.php:2080
+#: includes/custom-post-types/class-decker-tasks.php:2079
 msgid "Invalid comment data."
 msgstr ""
 
@@ -701,13 +701,13 @@ msgstr ""
 
 #: public/app-analytics.php:46
 #: public/app-analytics.php:49
-#: public/layouts/left-sidebar.php:246
+#: public/layouts/left-sidebar.php:251
 msgid "Analytics"
 msgstr ""
 
 #: public/app-analytics.php:61
 #: public/app-tasks.php:167
-#: public/layouts/left-sidebar.php:149
+#: public/layouts/left-sidebar.php:154
 msgid "Active Tasks"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 
 #: public/app-analytics.php:77
 #: public/app-tasks.php:171
-#: public/layouts/left-sidebar.php:175
+#: public/layouts/left-sidebar.php:180
 msgid "Archived Tasks"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgid "Task Detail"
 msgstr ""
 
 #: public/app-task-full.php:51
-#: public/layouts/left-sidebar.php:188
+#: public/layouts/left-sidebar.php:193
 msgid "New task"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgid "Task not found"
 msgstr ""
 
 #: public/app-tasks.php:169
-#: public/layouts/left-sidebar.php:162
+#: public/layouts/left-sidebar.php:167
 msgid "My Tasks"
 msgstr ""
 
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "Apps"
 msgstr ""
 
-#: public/layouts/left-sidebar.php:272
+#: public/layouts/left-sidebar.php:277
 msgid "Utilities"
 msgstr ""
 

--- a/public/assets/js/task-card.js
+++ b/public/assets/js/task-card.js
@@ -277,7 +277,7 @@
         const form = context.querySelector('#task-form');
 
         // Añadir event listeners a todos los inputs del formulario
-        const inputIds = ['task-title', 'task-due-date', 'task-board', 'task-stack', 'task-author-info', 'task-responsable', 'task-today', 'task-max-priority'];
+        const inputIds = ['task-title', 'task-due-date', 'task-board', 'task-stack', 'task-author-info', 'task-responsable', 'task-hidden', 'task-today', 'task-max-priority'];
 
         inputIds.forEach(function(id) {
             const element = context.querySelector(`#${id}`);
@@ -518,6 +518,7 @@
             stack: form.querySelector('#task-stack').value,
             author: form.querySelector('#task-author-info').value,
             responsable: form.querySelector('#task-responsable').value,
+            hidden: form.querySelector('#task-hidden').checked ? 1 : 0,
             assignees: selectedAssigneesValues,
             labels: selectedLabelsValues,
             description: quill.root.innerHTML,

--- a/public/layouts/left-sidebar.php
+++ b/public/layouts/left-sidebar.php
@@ -128,11 +128,16 @@ function decker_is_active_subpage( $get_parameter, $page ) {
 		<div class="collapse<?php echo ( 'tasks' === get_query_var( 'decker_page' ) ) ? ' show' : ''; ?>" id="sidebarTasks">
 		  <ul class="side-nav-second-level">
 			<?php
-			$active_tasks_count = wp_count_posts( 'decker_task' )->publish;
-			$task_manager                    = new taskManager();
-			$my_tasks                       = $task_manager->get_tasks_by_user( get_current_user_id() );
-			$my_tasks_count                 = count( $my_tasks );
-			$archived_tasks_count           = wp_count_posts( 'decker_task' )->archived;
+
+			$task_manager         = new taskManager();
+
+			$active_tasks         = $task_manager->get_tasks_by_status( 'publish' );
+			$active_tasks_count   = count( $active_tasks );
+
+			$my_tasks             = $task_manager->get_tasks_by_user( get_current_user_id() );
+			$my_tasks_count       = count( $my_tasks );
+
+			$archived_tasks_count = wp_count_posts( 'decker_task' )->archived;
 			?>
 			<li class="<?php echo esc_attr( decker_is_active_subpage( 'type', 'active' ) ); ?>"><span class="badge bg-success float-end"><?php echo esc_html( $active_tasks_count ); ?></span><a href="
 								  <?php

--- a/public/layouts/task-card.php
+++ b/public/layouts/task-card.php
@@ -463,10 +463,10 @@ function render_comments( array $task_comments, int $parent_id, int $current_use
 				<!-- Hidden Status -->
 				<div class="col-12 mb-3">
 					<div class="form-check form-switch">
-						<input class="form-check-input" type="checkbox" id="task-hidden" <?php checked($task->hidden); ?> <?php disabled($disabled); ?>>
+						<input class="form-check-input" type="checkbox" id="task-hidden" <?php checked( $task->hidden ); ?> <?php disabled( $disabled ); ?>>
 						<label class="form-check-label" for="task-hidden">
-							<?php esc_html_e('Hidden task', 'decker'); ?>
-							<small class="text-muted"><?php esc_html_e('(Hidden tasks are not shown in priority listings)', 'decker'); ?></small>
+							<?php esc_html_e( 'Hidden task', 'decker' ); ?>
+							<small class="text-muted"><?php esc_html_e( '(Hidden tasks are not shown in task listings)', 'decker' ); ?></small>
 						</label>
 					</div>
 				</div>

--- a/tests/includes/class-wp-unittest-factory-for-decker-task.php
+++ b/tests/includes/class-wp-unittest-factory-for-decker-task.php
@@ -39,6 +39,7 @@ class WP_UnitTest_Factory_For_Decker_Task extends WP_UnitTest_Factory_For_Post {
 				// 'duedate'      => null,
 				'author'       => 1, // default to user ID 1 (admin)
 				'responsable'  => 1, // default to user ID 1 (admin)
+				'hidden'       => false,
 				// 'assigned_users' => array(),
 				// 'labels'       => array(),
 				'post_type'    => 'decker_task',
@@ -138,6 +139,7 @@ class WP_UnitTest_Factory_For_Decker_Task extends WP_UnitTest_Factory_For_Post {
 			$args['duedate'],
 			$args['author'],
 			$args['responsable'],
+			$args['hidden'],
 			$args['assigned_users'],
 			$args['labels']
 		);

--- a/tests/integration/DeckerTasksIntegrationTest.php
+++ b/tests/integration/DeckerTasksIntegrationTest.php
@@ -261,6 +261,7 @@ class DeckerTasksIntegrationTest extends Decker_Test_Base {
 			$due_date,
 			get_current_user_id(),
 			get_current_user_id(),
+			false,
 			$user_ids,
 			$label_ids
 		);
@@ -299,6 +300,7 @@ class DeckerTasksIntegrationTest extends Decker_Test_Base {
 			$due_date,
 			get_current_user_id(),
 			get_current_user_id(),
+			false,
 			$user_ids,
 			$label_ids
 		);


### PR DESCRIPTION
This pull request introduces a new feature for handling hidden tasks in the Decker application, along with some minor translation updates. The main changes involve adding support for a `hidden` attribute to tasks, which allows tasks to be marked as hidden and excluded from certain views.

### Hidden Tasks Feature:

* `includes/class-decker-demo-data.php` and `includes/class-decker-email-to-post.php`: Added a `hidden` parameter to the `create_tasks` and `create_task` functions. [[1]](diffhunk://#diff-54230d7f950949036ad92a8d71bdc5569f2165679973d38ea0600fa87b85ed4bR159) [[2]](diffhunk://#diff-39f8630d351ce5f4d9a331d73957b870eba0113c6d462cc5cadf6982d05ac4cfR373)
* [`includes/custom-post-types/class-decker-tasks.php`](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1104-R1105): Added handling for the `hidden` attribute in multiple methods, including `display_meta_box`, `handle_save_decker_task`, and `create_or_update_task`. This includes adding form fields for the `hidden` attribute and ensuring it is properly saved and retrieved from the database. [[1]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1104-R1105) [[2]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1130-R1140) [[3]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1816-R1817) [[4]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1857) [[5]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1902) [[6]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1921) [[7]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R1990) [[8]](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5R2014-R2015)
* [`includes/models/class-task.php`](diffhunk://#diff-6ec7d871f4dab9befcef2e256e9576139588e8c50588179a5503a160d2c9054eR90-R96): Added the `hidden` attribute to the `Task` class and ensured it is considered when rendering task cards and constructing tasks. [[1]](diffhunk://#diff-6ec7d871f4dab9befcef2e256e9576139588e8c50588179a5503a160d2c9054eR90-R96) [[2]](diffhunk://#diff-6ec7d871f4dab9befcef2e256e9576139588e8c50588179a5503a160d2c9054eR172-R173) [[3]](diffhunk://#diff-6ec7d871f4dab9befcef2e256e9576139588e8c50588179a5503a160d2c9054eR438-R440)
* [`includes/models/class-taskmanager.php`](diffhunk://#diff-296407ce4c909c1b820e757f383519439e4cbef2dcca6e42563001d8cd2c7fcfR76-R87): Updated the `get_tasks_by_status` method to exclude hidden tasks from the results.

### Translation Updates:

* [`languages/decker-es_ES.po`](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL162-R163): Updated line numbers for various translation strings to reflect changes in the codebase. [[1]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL162-R163) [[2]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL218-R218) [[3]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL317-R394) [[4]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL454-R487) [[5]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL509-R515) [[6]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL525-R525) [[7]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL649-R649) [[8]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL658-R658) [[9]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL896-R896) [[10]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL921-R921) [[11]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL930-R934) [[12]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL958-R1002) [[13]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL1117-R1117)