### PR TITLE
92 fix scrollbar and modal size in knowledge base text viewer for long text

### DIFF
--- a/languages/decker-es_ES.po
+++ b/languages/decker-es_ES.po
@@ -604,7 +604,7 @@ msgstr "Sí"
 #: public/app-term-manager.php:290
 #: public/layouts/event-card.php:253
 #: public/layouts/kb-modal.php:82
-#: public/layouts/kb-view-modal.php:26
+#: public/layouts/kb-view-modal.php:30
 msgid "Close"
 msgstr "Cerrar"
 

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -1198,7 +1198,7 @@ msgstr ""
 #: public/app-term-manager.php:290
 #: public/layouts/event-card.php:253
 #: public/layouts/kb-modal.php:82
-#: public/layouts/kb-view-modal.php:26
+#: public/layouts/kb-view-modal.php:30
 msgid "Close"
 msgstr ""
 

--- a/public/assets/css/decker-public.css
+++ b/public/assets/css/decker-public.css
@@ -35,3 +35,20 @@ div.choices__list--dropdown .choices__item[aria-disabled="true"] {
 .choices__list--dropdown {
     z-index: 9999 !important;
 }
+
+
+#kb-view-modal .modal-dialog {
+    max-width: 90vw; /* Ensure it doesn't overflow horizontally */
+}
+
+#kb-view-modal .modal-content {
+    max-height: 90vh; /* Prevent modal from exceeding viewport height */
+    display: flex;
+    flex-direction: column;
+}
+
+#kb-view-modal .modal-body {
+    overflow-y: auto; /* Enables vertical scrolling */
+    max-height: 65vh; /* Adjust based on header/footer size */
+    padding: 1rem; /* Prevents content from touching edges */
+}

--- a/public/layouts/kb-view-modal.php
+++ b/public/layouts/kb-view-modal.php
@@ -23,6 +23,10 @@ defined( 'ABSPATH' ) || exit;
 			</div>
 			<div class="modal-footer">
 				<div id="kb-view-labels" class="me-auto"></div>
+				<button type="button" class="btn btn-outline-secondary btn-sm me-2" id="copy-kb-content" title="Copiar texto">
+					<i class="ri-file-copy-line"></i>
+				</button>
+  
 				<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?php esc_html_e( 'Close', 'decker' ); ?></button>
 			</div>
 		</div>
@@ -56,4 +60,31 @@ function viewArticle(id, title, content, labelsJson) {
 	
 	modal.modal('show');
 }
+
+// Función para copiar el contenido del modal al portapapeles usando Swal
+jQuery(document).ready(function($) {
+	$('#copy-kb-content').on('click', function() {
+		const textToCopy = $('#kb-view-content').text().trim();
+		if (!textToCopy) return;
+
+		navigator.clipboard.writeText(textToCopy).then(() => {
+			Swal.fire({
+				title: "¡Copiado!",
+				text: "El texto se ha copiado al portapapeles.",
+				icon: "success",
+				toast: true,
+				position: "top-end",
+				showConfirmButton: false,
+				timer: 2000
+			});
+		}).catch(err => {
+			Swal.fire({
+				title: "Error",
+				text: "No se pudo copiar el texto.",
+				icon: "error"
+			});
+			console.error('Error al copiar:', err);
+		});
+	});
+});
 </script>


### PR DESCRIPTION
This pull request includes several changes to improve the user interface and functionality of the knowledge base (KB) view modal. The most important changes include adding a copy-to-clipboard button, improving the modal's CSS for better usability, and updating translation files.

Improvements to KB view modal functionality:

* [`public/layouts/kb-view-modal.php`](diffhunk://#diff-ac9ca004d903b4f853fb17db8c7cccfcf8ff34f818ec75272a5fa16ed82de797R26-R29): Added a copy-to-clipboard button in the modal footer and implemented the corresponding JavaScript functionality to copy the modal content to the clipboard and show a success or error message using Swal. [[1]](diffhunk://#diff-ac9ca004d903b4f853fb17db8c7cccfcf8ff34f818ec75272a5fa16ed82de797R26-R29) [[2]](diffhunk://#diff-ac9ca004d903b4f853fb17db8c7cccfcf8ff34f818ec75272a5fa16ed82de797R63-R89)

CSS enhancements for KB view modal:

* [`public/assets/css/decker-public.css`](diffhunk://#diff-aef7a574128c62e4716d1f54bcb754e457670879499c494fc4af68b054685be2R38-R54): Added CSS rules to ensure that the KB view modal does not overflow horizontally or vertically, and enabled vertical scrolling within the modal body.

Translation updates:

* [`languages/decker-es_ES.po`](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL607-R607): Updated the line reference for the "Close" translation.
* [`languages/decker.pot`](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L1201-R1201): Updated the line reference for the "Close" translation.