### PR TITLE
Add gitlab release pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,7 +15,7 @@ CONVENTIONS.md             export-ignore
 docker-compose.yml         export-ignore
 docs/                      export-ignore
 Makefile                   export-ignore
-mkdocs.yml                 export-ignore	
+mkdocs.yml                 export-ignore
 node_modules/              export-ignore
 package-lock.json          export-ignore
 package.json               export-ignore
@@ -28,3 +28,4 @@ sftp-config.json           export-ignore
 test.php                   export-ignore
 tests/                     export-ignore
 /vendor/                   export-ignore
+*.css.map 				   export-ignore

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,37 @@
+stages:
+  - build
+  - release
+
+variables:
+  RELEASE_TAG: $CI_COMMIT_TAG
+
+build_package:
+  stage: build
+  image: ubuntu:latest
+  before_script:
+    - apt update && apt install -y make zip
+  script:
+    - make package VERSION=${RELEASE_TAG}
+    - mv decker-${RELEASE_TAG}.zip decker-latest.zip
+  artifacts:
+    paths:
+      - decker-${RELEASE_TAG}.zip
+      - decker-latest.zip
+    expire_in: 1 week
+
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  script:
+    - echo "Releasing ${RELEASE_TAG}"
+  release:
+    name: "Release ${RELEASE_TAG}"
+    tag_name: "${RELEASE_TAG}"
+    description: "New release ${RELEASE_TAG}"
+    assets:
+      links:
+        - name: "Download decker-${RELEASE_TAG}.zip"
+          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download"
+        - name: "Latest package"
+          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file_type=archive"
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,18 +36,22 @@ upload:
       curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
            --upload-file "${PACKAGE_BINARY}.zip" \
            "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
-           
+
 release:
   stage: release
   image: registry.gitlab.com/gitlab-org/release-cli:latest
   only:
     - tags
   needs: ["upload"]
+
   script:
-    - |
-      release-cli create \
-        --name "Release ${CI_COMMIT_TAG}" \
-        --tag-name "${CI_COMMIT_TAG}" \
-        --description "Release for ${CI_COMMIT_TAG}" \
-        --assets-link "{\"name\":\"${PACKAGE_BINARY}.zip\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip\"}"
+    - echo "Creating GitLab release for tag ${PACKAGE_VERSION}"
+  release:
+    name: "Release ${PACKAGE_VERSION}"
+    tag_name: "${CI_COMMIT_TAG}"
+    description: "Release for ${PACKAGE_VERSION}"
+    assets:
+      links:
+        - name: "${PACKAGE_BINARY}.zip"
+          url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,14 +11,29 @@ build_package:
     - tags
   before_script:
     - apt-get update && apt-get install -y make zip composer
+    - composer --version
   script:
-    # Run the Makefile to generate the ZIP package
     - make package VERSION="${RELEASE_TAG}"
-    - ls -lh decker-"${RELEASE_TAG}".zip
+    - ls -lh decker-v${RELEASE_TAG}.zip
   artifacts:
     paths:
-      - decker-"${RELEASE_TAG}".zip
+      - decker-v${RELEASE_TAG}.zip
     expire_in: 1 week
+
+# build_package:
+#   stage: build
+#   only:
+#     - tags
+#   before_script:
+#     - apt-get update && apt-get install -y make zip composer
+#   script:
+#     # Run the Makefile to generate the ZIP package
+#     - make package VERSION="${RELEASE_TAG}"
+#     - ls -lh decker-"${RELEASE_TAG}".zip
+#   artifacts:
+#     paths:
+#       - decker-"${RELEASE_TAG}".zip
+#     expire_in: 1 week
 
 release:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,11 +7,10 @@ variables:
 
 build_package:
   stage: build
-  image: ubuntu:latest
   only:
     - tags
   before_script:
-    - apt-get update && apt-get install -y make zip
+    - apt-get update && apt-get install -y make zip composer
   script:
     # Run the Makefile to generate the ZIP package
     - make package VERSION="${RELEASE_TAG}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,14 +4,14 @@ stages:
   - release
 
 variables:
+  # Package version should match \A(\.?[\w\+-]+\.?)+\z regular expresion.
+  # See https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
   PACKAGE_VERSION: "${CI_COMMIT_TAG}"
   PACKAGE_BINARY: "decker-${PACKAGE_VERSION}"
   PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/decker/${PACKAGE_VERSION}"
 
 build:
   stage: build
-  # Puedes usar 'rules:' o 'only:', pero no ambos mezclados 
-  # para la misma condición
   only:
     - tags
   before_script:
@@ -30,7 +30,7 @@ upload:
   image: curlimages/curl:latest
   only:
     - tags
-  needs: ["build"] # Para asegurar que vea el artifact del build
+  needs: ["build"]
   script:
     - |
       curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
@@ -42,161 +42,28 @@ release:
   image: registry.gitlab.com/gitlab-org/release-cli:latest
   only:
     - tags
-  needs: ["upload"] # Asegura que se ejecute después de subir el archivo
+  needs: ["upload"]
+
   script:
-    - |
-      release-cli create \
-        --name "Release ${CI_COMMIT_TAG}" \
-        --tag-name "${CI_COMMIT_TAG}" \
-        --description "Release for ${CI_COMMIT_TAG}" \
-        --assets-link "{\"name\":\"${PACKAGE_BINARY}.zip\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip\"}"
+    - echo "Creating GitLab release for tag ${RELEASE_TAG}"
 
-
-# stages:
-#   - build
-#   - upload
-#   - release
-
-# variables:
-#   # Package version should match \A(\.?[\w\+-]+\.?)+\z regular expresion.
-#   # See https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
-#   PACKAGE_VERSION: "${CI_COMMIT_TAG}"
-#   PACKAGE_BINARY: "decker-${PACKAGE_VERSION}"
-#   PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/decker/${PACKAGE_VERSION}"
-
-# build:
-#   stage: build
-#   rules:
-#     - if: $CI_COMMIT_TAG
-#   only:
-#     - tags
-#   before_script:
-#     - apt-get update && apt-get install -y make zip composer
-#     - composer --version
-#   # script:
-#     - make package VERSION="${PACKAGE_VERSION}"
-#     - ls -lh decker-${PACKAGE_VERSION}.zip
-#   artifacts:
-#     paths:
-#       - decker-${PACKAGE_VERSION}.zip
-#     expire_in: 1 week
-
-# upload:
-#   stage: upload
-#   image: curlimages/curl:latest
-#   rules:
-#     - if: $CI_COMMIT_TAG
-#   script:
-#     - |
-#       curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --upload-file ${PACKAGE_BINARY}.zip ${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip
-
-# release:
-#   # Caution, as of 2021-02-02 these assets links require a login, see:
-#   # https://gitlab.com/gitlab-org/gitlab/-/issues/299384
-#   stage: release
-#   image: registry.gitlab.com/gitlab-org/release-cli:latest
-#   rules:
-#     - if: $CI_COMMIT_TAG
-#   script:
-#     - |
-#       release-cli create --name "Release $CI_COMMIT_TAG" --tag-name $CI_COMMIT_TAG \
-#         --assets-link "{\"name\":\"${PACKAGE_BINARY}\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}\"}" \
+  release:
+    name: "Release ${RELEASE_TAG}"
+    tag_name: "${RELEASE_TAG}"
+    description: "New release ${RELEASE_TAG}"
+    assets:
+      links:
+        - name: "${PACKAGE_BINARY}.zip"
+          url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
 
 
 
-# # stages:
-# #   - build
-# #   - release
 
-# # variables:
-# #   RELEASE_TAG: "${CI_COMMIT_TAG}"
-
-# # build_package:
-# #   stage: build
-# #   only:
-# #     - tags
-# #   before_script:
-# #     - apt-get update && apt-get install -y make zip composer
-# #     - composer --version
-# #   script:
-# #     - make package VERSION="${RELEASE_TAG}"
-# #     - ls -lh decker-${RELEASE_TAG}.zip
-# #   artifacts:
-# #     paths:
-# #       - decker-${RELEASE_TAG}.zip
-# #     expire_in: 1 week
-
-# # release:
-# #   stage: release
-# #   image: registry.gitlab.com/gitlab-org/release-cli:latest
-# #   needs: ["build_package"]  # Asegura que este job dependa del artefacto
-# #   only:
-# #     - tags
-# #   script:
-# #     - echo "Creando Release en GitLab para el tag ${RELEASE_TAG}"
-# #   release:
-# #     name: "Release ${RELEASE_TAG}"
-# #     tag_name: "${RELEASE_TAG}"
-# #     description: "New release ${RELEASE_TAG}"
-# #     assets:
-# #       links:
-# #         - name: "decker-${RELEASE_TAG}.zip"
-# #           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/raw/decker-${RELEASE_TAG}.zip?inline=false"
-# #           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/raw/decker-${RELEASE_TAG}.zip}"
-
-# #         --assets-link "{\"name\":\"${LINUX_AMD64_BINARY}\",\"url\":\"${PACKAGE_REGISTRY_URL}/${LINUX_AMD64_BINARY}\"}"
-
-
-# # # stages:
-# # #   - build
-# # #   - release
-
-# # # variables:
-# # #   RELEASE_TAG: "${CI_COMMIT_TAG}"
-
-# # # build_package:
-# # #   stage: build
-# # #   only:
-# # #     - tags
-# # #   before_script:
-# # #     - apt-get update && apt-get install -y make zip composer
-# # #     - composer --version
-# # #   script:
-# # #     - make package VERSION="${RELEASE_TAG}"
-# # #     - ls -lh decker-${RELEASE_TAG}.zip
-# # #   artifacts:
-# # #     paths:
-# # #       - decker-${RELEASE_TAG}.zip
-# # #     expire_in: 1 week
-
-# # # # build_package:
-# # # #   stage: build
-# # # #   only:
-# # # #     - tags
-# # # #   before_script:
-# # # #     - apt-get update && apt-get install -y make zip composer
-# # # #   script:
-# # # #     # Run the Makefile to generate the ZIP package
-# # # #     - make package VERSION="${RELEASE_TAG}"
-# # # #     - ls -lh decker-"${RELEASE_TAG}".zip
-# # # #   artifacts:
-# # # #     paths:
-# # # #       - decker-"${RELEASE_TAG}".zip
-# # # #     expire_in: 1 week
-
-# # # release:
-# # #   stage: release
-# # #   image: registry.gitlab.com/gitlab-org/release-cli:latest
-# # #   only:
-# # #     - tags
-# # #   script:
-# # #     - echo "Creating GitLab release for tag ${RELEASE_TAG}"
-# # #   release:
-# # #     name: "Release ${RELEASE_TAG}"
-# # #     tag_name: "${RELEASE_TAG}"
-# # #     description: "New release ${RELEASE_TAG}"
-# # #     assets:
-# # #       links:
-# # #         - name: "decker-${RELEASE_TAG}.zip"
-# # #           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file=decker-${RELEASE_TAG}.zip"
+  # script:
+  #   - |
+  #     release-cli create \
+  #       --name "Release ${CI_COMMIT_TAG}" \
+  #       --tag-name "${CI_COMMIT_TAG}" \
+  #       --description "Release for ${CI_COMMIT_TAG}" \
+  #       --assets-link "{\"name\":\"${PACKAGE_BINARY}.zip\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip\"}"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,10 +14,10 @@ build_package:
     - composer --version
   script:
     - make package VERSION="${RELEASE_TAG}"
-    - ls -lh decker-v${RELEASE_TAG}.zip
+    - ls -lh decker-${RELEASE_TAG}.zip
   artifacts:
     paths:
-      - decker-v${RELEASE_TAG}.zip
+      - decker-${RELEASE_TAG}.zip
     expire_in: 1 week
 
 # build_package:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,12 +43,11 @@ release:
   script:
     - echo "Creating GitLab release for tag ${RELEASE_TAG}"
   release:
-    # Creates a new release entry in GitLab
     name: "Release ${RELEASE_TAG}"
     tag_name: "${RELEASE_TAG}"
     description: "New release ${RELEASE_TAG}"
     assets:
-      # Adds a direct link to download the artifact
       links:
-        - name: "Download decker-${RELEASE_TAG}.zip"
-          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download"
+        - name: "decker-${RELEASE_TAG}.zip"
+          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file=decker-${RELEASE_TAG}.zip"
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,34 +20,72 @@ build_package:
       - decker-${RELEASE_TAG}.zip
     expire_in: 1 week
 
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  needs: ["build_package"]  # Asegura que este job dependa del artefacto
+  only:
+    - tags
+  script:
+    - echo "Creando Release en GitLab para el tag ${RELEASE_TAG}"
+  release:
+    name: "Release ${RELEASE_TAG}"
+    tag_name: "${RELEASE_TAG}"
+    description: "Nueva versión ${RELEASE_TAG}"
+    assets:
+      links:
+        - name: "decker-${RELEASE_TAG}.zip"
+          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/raw/decker-${RELEASE_TAG}.zip?inline=false"
+# stages:
+#   - build
+#   - release
+
+# variables:
+#   RELEASE_TAG: "${CI_COMMIT_TAG}"
+
 # build_package:
 #   stage: build
 #   only:
 #     - tags
 #   before_script:
 #     - apt-get update && apt-get install -y make zip composer
+#     - composer --version
 #   script:
-#     # Run the Makefile to generate the ZIP package
 #     - make package VERSION="${RELEASE_TAG}"
-#     - ls -lh decker-"${RELEASE_TAG}".zip
+#     - ls -lh decker-${RELEASE_TAG}.zip
 #   artifacts:
 #     paths:
-#       - decker-"${RELEASE_TAG}".zip
+#       - decker-${RELEASE_TAG}.zip
 #     expire_in: 1 week
 
-release:
-  stage: release
-  image: registry.gitlab.com/gitlab-org/release-cli:latest
-  only:
-    - tags
-  script:
-    - echo "Creating GitLab release for tag ${RELEASE_TAG}"
-  release:
-    name: "Release ${RELEASE_TAG}"
-    tag_name: "${RELEASE_TAG}"
-    description: "New release ${RELEASE_TAG}"
-    assets:
-      links:
-        - name: "decker-${RELEASE_TAG}.zip"
-          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file=decker-${RELEASE_TAG}.zip"
+# # build_package:
+# #   stage: build
+# #   only:
+# #     - tags
+# #   before_script:
+# #     - apt-get update && apt-get install -y make zip composer
+# #   script:
+# #     # Run the Makefile to generate the ZIP package
+# #     - make package VERSION="${RELEASE_TAG}"
+# #     - ls -lh decker-"${RELEASE_TAG}".zip
+# #   artifacts:
+# #     paths:
+# #       - decker-"${RELEASE_TAG}".zip
+# #     expire_in: 1 week
+
+# release:
+#   stage: release
+#   image: registry.gitlab.com/gitlab-org/release-cli:latest
+#   only:
+#     - tags
+#   script:
+#     - echo "Creating GitLab release for tag ${RELEASE_TAG}"
+#   release:
+#     name: "Release ${RELEASE_TAG}"
+#     tag_name: "${RELEASE_TAG}"
+#     description: "New release ${RELEASE_TAG}"
+#     assets:
+#       links:
+#         - name: "decker-${RELEASE_TAG}.zip"
+#           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file=decker-${RELEASE_TAG}.zip"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,34 +36,18 @@ upload:
       curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
            --upload-file "${PACKAGE_BINARY}.zip" \
            "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
-
+           
 release:
   stage: release
   image: registry.gitlab.com/gitlab-org/release-cli:latest
   only:
     - tags
   needs: ["upload"]
-
   script:
-    - echo "Creating GitLab release for tag ${RELEASE_TAG}"
-
-  release:
-    name: "Release ${RELEASE_TAG}"
-    tag_name: "${CI_COMMIT_TAG}"
-    description: "Release for ${RELEASE_TAG}"
-    assets:
-      links:
-        - name: "${PACKAGE_BINARY}.zip"
-          url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
-
-
-
-
-  # script:
-  #   - |
-  #     release-cli create \
-  #       --name "Release ${CI_COMMIT_TAG}" \
-  #       --tag-name "${CI_COMMIT_TAG}" \
-  #       --description "Release for ${CI_COMMIT_TAG}" \
-  #       --assets-link "{\"name\":\"${PACKAGE_BINARY}.zip\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip\"}"
+    - |
+      release-cli create \
+        --name "Release ${CI_COMMIT_TAG}" \
+        --tag-name "${CI_COMMIT_TAG}" \
+        --description "Release for ${CI_COMMIT_TAG}" \
+        --assets-link "{\"name\":\"${PACKAGE_BINARY}.zip\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip\"}"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,62 +1,115 @@
 stages:
   - build
+  - upload
   - release
 
 variables:
-  RELEASE_TAG: "${CI_COMMIT_TAG}"
+  PACKAGE_VERSION: "${CI_COMMIT_TAG}"
+  PACKAGE_BINARY: "decker-${PACKAGE_VERSION}"
+  PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/decker/${PACKAGE_VERSION}"
 
-build_package:
+build:
   stage: build
+  # Puedes usar 'rules:' o 'only:', pero no ambos mezclados 
+  # para la misma condición
   only:
     - tags
   before_script:
     - apt-get update && apt-get install -y make zip composer
     - composer --version
   script:
-    - make package VERSION="${RELEASE_TAG}"
-    - ls -lh decker-${RELEASE_TAG}.zip
+    - make package VERSION="${PACKAGE_VERSION}"
+    - ls -lh "decker-${PACKAGE_VERSION}.zip"
   artifacts:
     paths:
-      - decker-${RELEASE_TAG}.zip
+      - "decker-${PACKAGE_VERSION}.zip"
     expire_in: 1 week
+
+upload:
+  stage: upload
+  image: curlimages/curl:latest
+  only:
+    - tags
+  needs: ["build"] # Para asegurar que vea el artifact del build
+  script:
+    - |
+      curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+           --upload-file "${PACKAGE_BINARY}.zip" \
+           "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
 
 release:
   stage: release
   image: registry.gitlab.com/gitlab-org/release-cli:latest
-  needs: ["build_package"]  # Asegura que este job dependa del artefacto
   only:
     - tags
+  needs: ["upload"] # Asegura que se ejecute después de subir el archivo
   script:
-    - echo "Creando Release en GitLab para el tag ${RELEASE_TAG}"
-  release:
-    name: "Release ${RELEASE_TAG}"
-    tag_name: "${RELEASE_TAG}"
-    description: "Nueva versión ${RELEASE_TAG}"
-    assets:
-      links:
-        - name: "decker-${RELEASE_TAG}.zip"
-          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/raw/decker-${RELEASE_TAG}.zip?inline=false"
+    - |
+      release-cli create \
+        --name "Release ${CI_COMMIT_TAG}" \
+        --tag-name "${CI_COMMIT_TAG}" \
+        --description "Release for ${CI_COMMIT_TAG}" \
+        --assets-link "{\"name\":\"${PACKAGE_BINARY}.zip\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip\"}"
+
+
 # stages:
 #   - build
+#   - upload
 #   - release
 
 # variables:
-#   RELEASE_TAG: "${CI_COMMIT_TAG}"
+#   # Package version should match \A(\.?[\w\+-]+\.?)+\z regular expresion.
+#   # See https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
+#   PACKAGE_VERSION: "${CI_COMMIT_TAG}"
+#   PACKAGE_BINARY: "decker-${PACKAGE_VERSION}"
+#   PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/decker/${PACKAGE_VERSION}"
 
-# build_package:
+# build:
 #   stage: build
+#   rules:
+#     - if: $CI_COMMIT_TAG
 #   only:
 #     - tags
 #   before_script:
 #     - apt-get update && apt-get install -y make zip composer
 #     - composer --version
-#   script:
-#     - make package VERSION="${RELEASE_TAG}"
-#     - ls -lh decker-${RELEASE_TAG}.zip
+#   # script:
+#     - make package VERSION="${PACKAGE_VERSION}"
+#     - ls -lh decker-${PACKAGE_VERSION}.zip
 #   artifacts:
 #     paths:
-#       - decker-${RELEASE_TAG}.zip
+#       - decker-${PACKAGE_VERSION}.zip
 #     expire_in: 1 week
+
+# upload:
+#   stage: upload
+#   image: curlimages/curl:latest
+#   rules:
+#     - if: $CI_COMMIT_TAG
+#   script:
+#     - |
+#       curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" --upload-file ${PACKAGE_BINARY}.zip ${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip
+
+# release:
+#   # Caution, as of 2021-02-02 these assets links require a login, see:
+#   # https://gitlab.com/gitlab-org/gitlab/-/issues/299384
+#   stage: release
+#   image: registry.gitlab.com/gitlab-org/release-cli:latest
+#   rules:
+#     - if: $CI_COMMIT_TAG
+#   script:
+#     - |
+#       release-cli create --name "Release $CI_COMMIT_TAG" --tag-name $CI_COMMIT_TAG \
+#         --assets-link "{\"name\":\"${PACKAGE_BINARY}\",\"url\":\"${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}\"}" \
+
+
+
+# # stages:
+# #   - build
+# #   - release
+
+# # variables:
+# #   RELEASE_TAG: "${CI_COMMIT_TAG}"
 
 # # build_package:
 # #   stage: build
@@ -64,28 +117,86 @@ release:
 # #     - tags
 # #   before_script:
 # #     - apt-get update && apt-get install -y make zip composer
+# #     - composer --version
 # #   script:
-# #     # Run the Makefile to generate the ZIP package
 # #     - make package VERSION="${RELEASE_TAG}"
-# #     - ls -lh decker-"${RELEASE_TAG}".zip
+# #     - ls -lh decker-${RELEASE_TAG}.zip
 # #   artifacts:
 # #     paths:
-# #       - decker-"${RELEASE_TAG}".zip
+# #       - decker-${RELEASE_TAG}.zip
 # #     expire_in: 1 week
 
-# release:
-#   stage: release
-#   image: registry.gitlab.com/gitlab-org/release-cli:latest
-#   only:
-#     - tags
-#   script:
-#     - echo "Creating GitLab release for tag ${RELEASE_TAG}"
-#   release:
-#     name: "Release ${RELEASE_TAG}"
-#     tag_name: "${RELEASE_TAG}"
-#     description: "New release ${RELEASE_TAG}"
-#     assets:
-#       links:
-#         - name: "decker-${RELEASE_TAG}.zip"
-#           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file=decker-${RELEASE_TAG}.zip"
+# # release:
+# #   stage: release
+# #   image: registry.gitlab.com/gitlab-org/release-cli:latest
+# #   needs: ["build_package"]  # Asegura que este job dependa del artefacto
+# #   only:
+# #     - tags
+# #   script:
+# #     - echo "Creando Release en GitLab para el tag ${RELEASE_TAG}"
+# #   release:
+# #     name: "Release ${RELEASE_TAG}"
+# #     tag_name: "${RELEASE_TAG}"
+# #     description: "New release ${RELEASE_TAG}"
+# #     assets:
+# #       links:
+# #         - name: "decker-${RELEASE_TAG}.zip"
+# #           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/raw/decker-${RELEASE_TAG}.zip?inline=false"
+# #           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/raw/decker-${RELEASE_TAG}.zip}"
+
+# #         --assets-link "{\"name\":\"${LINUX_AMD64_BINARY}\",\"url\":\"${PACKAGE_REGISTRY_URL}/${LINUX_AMD64_BINARY}\"}"
+
+
+# # # stages:
+# # #   - build
+# # #   - release
+
+# # # variables:
+# # #   RELEASE_TAG: "${CI_COMMIT_TAG}"
+
+# # # build_package:
+# # #   stage: build
+# # #   only:
+# # #     - tags
+# # #   before_script:
+# # #     - apt-get update && apt-get install -y make zip composer
+# # #     - composer --version
+# # #   script:
+# # #     - make package VERSION="${RELEASE_TAG}"
+# # #     - ls -lh decker-${RELEASE_TAG}.zip
+# # #   artifacts:
+# # #     paths:
+# # #       - decker-${RELEASE_TAG}.zip
+# # #     expire_in: 1 week
+
+# # # # build_package:
+# # # #   stage: build
+# # # #   only:
+# # # #     - tags
+# # # #   before_script:
+# # # #     - apt-get update && apt-get install -y make zip composer
+# # # #   script:
+# # # #     # Run the Makefile to generate the ZIP package
+# # # #     - make package VERSION="${RELEASE_TAG}"
+# # # #     - ls -lh decker-"${RELEASE_TAG}".zip
+# # # #   artifacts:
+# # # #     paths:
+# # # #       - decker-"${RELEASE_TAG}".zip
+# # # #     expire_in: 1 week
+
+# # # release:
+# # #   stage: release
+# # #   image: registry.gitlab.com/gitlab-org/release-cli:latest
+# # #   only:
+# # #     - tags
+# # #   script:
+# # #     - echo "Creating GitLab release for tag ${RELEASE_TAG}"
+# # #   release:
+# # #     name: "Release ${RELEASE_TAG}"
+# # #     tag_name: "${RELEASE_TAG}"
+# # #     description: "New release ${RELEASE_TAG}"
+# # #     assets:
+# # #       links:
+# # #         - name: "decker-${RELEASE_TAG}.zip"
+# # #           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file=decker-${RELEASE_TAG}.zip"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,35 +3,38 @@ stages:
   - release
 
 variables:
-  RELEASE_TAG: $CI_COMMIT_TAG
+  RELEASE_TAG: "${CI_COMMIT_TAG}"
 
 build_package:
   stage: build
   image: ubuntu:latest
+  only:
+    - tags
   before_script:
-    - apt update && apt install -y make zip
+    - apt-get update && apt-get install -y make zip
   script:
-    - make package VERSION=${RELEASE_TAG}
-    - mv decker-${RELEASE_TAG}.zip decker-latest.zip
+    # Run the Makefile to generate the ZIP package
+    - make package VERSION="${RELEASE_TAG}"
+    - ls -lh decker-"${RELEASE_TAG}".zip
   artifacts:
     paths:
-      - decker-${RELEASE_TAG}.zip
-      - decker-latest.zip
+      - decker-"${RELEASE_TAG}".zip
     expire_in: 1 week
 
 release:
   stage: release
   image: registry.gitlab.com/gitlab-org/release-cli:latest
+  only:
+    - tags
   script:
-    - echo "Releasing ${RELEASE_TAG}"
+    - echo "Creating GitLab release for tag ${RELEASE_TAG}"
   release:
+    # Creates a new release entry in GitLab
     name: "Release ${RELEASE_TAG}"
     tag_name: "${RELEASE_TAG}"
     description: "New release ${RELEASE_TAG}"
     assets:
+      # Adds a direct link to download the artifact
       links:
         - name: "Download decker-${RELEASE_TAG}.zip"
           url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download"
-        - name: "Latest package"
-          url: "${CI_PROJECT_URL}/-/jobs/${CI_JOB_ID}/artifacts/download?file_type=archive"
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,8 +49,8 @@ release:
 
   release:
     name: "Release ${RELEASE_TAG}"
-    tag_name: "${RELEASE_TAG}"
-    description: "New release ${RELEASE_TAG}"
+    tag_name: "${CI_COMMIT_TAG}"
+    description: "Release for ${RELEASE_TAG}"
     assets:
       links:
         - name: "${PACKAGE_BINARY}.zip"


### PR DESCRIPTION
This pull request includes updates to the `.gitattributes` and `.gitlab-ci.yml` files to improve the project's configuration and CI/CD pipeline. The most important changes include adding a new file type to the export-ignore list and defining a multi-stage pipeline in GitLab CI.

Updates to `.gitattributes`:

* Added `*.css.map` to the export-ignore list to prevent CSS source maps from being included in exports.

Enhancements to GitLab CI/CD pipeline:

* Defined stages (`build`, `upload`, `release`) in the `.gitlab-ci.yml` file to structure the CI/CD process.
* Added variables for package versioning and registry URL configuration.
* Implemented a `build` job to package the project, including installing necessary dependencies and creating an artifact.
* Created an `upload` job to upload the package artifact to the GitLab package registry.
* Added a `release` job to create a GitLab release with a description and asset links.