### PR TITLE
Improved pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
-  - build
-  - upload
+  # Disabled build and upload stages until get internet connection on Gitlab Runner  
+  # - build
+  # - upload
   - release
 
 variables:
@@ -10,32 +11,33 @@ variables:
   PACKAGE_BINARY: "decker-${PACKAGE_VERSION}"
   PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/decker/${PACKAGE_VERSION}"
 
-build:
-  stage: build
-  only:
-    - tags
-  before_script:
-    - apt-get update && apt-get install -y make zip composer
-    - composer --version
-  script:
-    - make package VERSION="${PACKAGE_VERSION}"
-    - ls -lh "decker-${PACKAGE_VERSION}.zip"
-  artifacts:
-    paths:
-      - "decker-${PACKAGE_VERSION}.zip"
-    expire_in: 1 week
+# Disabled build and upload stages until get internet connection on Gitlab Runner
+# build:
+#   stage: build
+#   only:
+#     - tags
+#   before_script:
+#     - apt-get update && apt-get install -y make zip composer
+#     - composer --version
+#   script:
+#     - make package VERSION="${PACKAGE_VERSION}"
+#     - ls -lh "decker-${PACKAGE_VERSION}.zip"
+#   artifacts:
+#     paths:
+#       - "decker-${PACKAGE_VERSION}.zip"
+#     expire_in: 1 week
 
-upload:
-  stage: upload
-  image: curlimages/curl:latest
-  only:
-    - tags
-  needs: ["build"]
-  script:
-    - |
-      curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
-           --upload-file "${PACKAGE_BINARY}.zip" \
-           "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
+# upload:
+#   stage: upload
+#   image: curlimages/curl:latest
+#   only:
+#     - tags
+#   needs: ["build"]
+#   script:
+#     - |
+#       curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+#            --upload-file "${PACKAGE_BINARY}.zip" \
+#            "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
 
 release:
   stage: release
@@ -53,5 +55,7 @@ release:
     assets:
       links:
         - name: "${PACKAGE_BINARY}.zip"
-          url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
+          # Disabled build and upload stages until get internet connection on Gitlab Runner
+          # url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
+          url: "https://github.com/ateeducacion/wp-decker/releases/download/${PACKAGE_VERSION}/${PACKAGE_BINARY}"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,8 @@ release:
   image: registry.gitlab.com/gitlab-org/release-cli:latest
   only:
     - tags
-  needs: ["upload"]
+  # Disabled build and upload stages until get internet connection on Gitlab Runner      
+  # needs: ["upload"]
 
   script:
     - echo "Creating GitLab release for tag ${PACKAGE_VERSION}"


### PR DESCRIPTION
This pull request includes changes to the `.gitlab-ci.yml` file, primarily disabling the build and upload stages due to a lack of internet connection on the GitLab Runner. Additionally, it modifies the release stage to use a different URL for the package binary.

Key changes:

* Disabled the `build` and `upload` stages in the `.gitlab-ci.yml` file until an internet connection is available on the GitLab Runner. [[1]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L2-R4) [[2]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L13-R40)
* Updated the `release` stage to use a GitHub URL for the package binary instead of the package registry URL.