### PR TITLE
Fix url for zip release download

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,5 +58,5 @@ release:
         - name: "${PACKAGE_BINARY}.zip"
           # Disabled build and upload stages until get internet connection on Gitlab Runner
           # url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
-          url: "https://github.com/ateeducacion/wp-decker/releases/download/${PACKAGE_VERSION}/${PACKAGE_BINARY}"
+          url: "https://github.com/ateeducacion/wp-decker/releases/download/${PACKAGE_VERSION}/${PACKAGE_BINARY}.zip"
 


### PR DESCRIPTION
This pull request includes a small change to the `.gitlab-ci.yml` file. The change corrects the URL for the package binary in the `release` stage by appending `.zip` to the end of the URL.