### PR TITLE
Add test url on PR and action summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,27 @@ jobs:
 
       - name: Run unit tests
         run: make test
+
+
+      # Add test URL to workflow summary
+      - name: Add test URL to summary
+        run: echo "🔗 [Test the branch here](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
+
+      # Create a GitHub Check Run with the test URL
+      - name: Create a check with a test link
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Test Deployment",
+              head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
+              status: "completed",
+              conclusion: "success",
+              output: {
+                title: "Test Deployment Ready",
+                summary: "You can test the branch here: [Test the branch](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)"
+              }
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,30 @@ jobs:
         run: make test
 
 
+      # Set branch name variable for blueprint URL based on event type
+      - name: Set branch name for blueprint URL
+        shell: bash
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          fi
+
       # Add test URL to workflow summary
       - name: Add test URL to summary
-        run: echo "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
+        run: echo "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/$BRANCH_NAME/blueprint.json" >> $GITHUB_STEP_SUMMARY
 
       # Create a GitHub Check Run with the test URL
       - name: Create a check with a test link
         uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const branchName = process.env.BRANCH_NAME;
+            const testUrl = `https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${branchName}/blueprint.json`;
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -74,6 +88,6 @@ jobs:
               conclusion: "skipped",
               output: {
                 title: "Test in WP playground",
-                summary: "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json"
+                summary: testUrl
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
               name: "Test on WP playground",
               head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
               status: "completed",
-              conclusion: "success",
+              conclusion: "skipped",
               output: {
-                title: "Test Deployment Ready",
+                title: "Test in WP playground",
                 summary: "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json"
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Add test URL to workflow summary
       - name: Add test URL to summary
-        run: echo "🔗 [Test the branch here](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
+        run: echo "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
 
       # Create a GitHub Check Run with the test URL
       - name: Create a check with a test link
@@ -68,12 +68,12 @@ jobs:
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: "Test Deployment",
+              name: "Test on WP playground",
               head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
               status: "completed",
               conclusion: "success",
               output: {
                 title: "Test Deployment Ready",
-                summary: "You can test the branch here: [Test the branch](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)"
+                summary: "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json"
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
               name: "Test on WP playground",
               head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
               status: "completed",
-              conclusion: "skipped",
+              conclusion: "neutral",
               output: {
                 title: "Test in WP playground",
                 summary: testUrl


### PR DESCRIPTION
This pull request includes enhancements to the CI workflow to improve the visibility and accessibility of test deployments. The most important changes are as follows:

Enhancements to CI workflow:

* Added a step to include a test URL in the workflow summary, providing a direct link to test the branch. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlR56-R79](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR56-R79))
* Created a GitHub Check Run with the test URL, making it easier to access and verify test deployments directly from the pull request checks. (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlR56-R79](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR56-R79))