### PR TITLE
Add playground url on pr (improved version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       # Show final Playground URL in the Summary
       - name: Add Playground URL to summary
         run: |
-          echo "https://playground.wordpress.net/?blueprint=${ENCODED_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
+          echo "https://playground.wordpress.net/#${ENCODED_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
 
       # Create a GitHub Check Run with the Playground URL
       - name: Create a check with a test link
@@ -91,7 +91,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const encodedBlueprint = process.env.ENCODED_BLUEPRINT;
-            const playgroundUrl = `https://playground.wordpress.net/?blueprint=${encodedBlueprint}`;
+            const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,27 @@ jobs:
 
       - name: Run unit tests
         run: make test
+
+
+      # Add test URL to workflow summary
+      - name: Add test URL to summary
+        run: echo "🔗 [Test the branch here](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
+
+      # Create a GitHub Check Run with the test URL
+      - name: Create a check with a test link
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Test Deployment",
+              head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
+              status: "completed",
+              conclusion: "success",
+              output: {
+                title: "Test Deployment Ready",
+                summary: "You can test the branch here: [Test the branch](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)"
+              }
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Encode blueprint for Playground
         id: blueprint
         run: |
-          JSON_BLUEPRINT=$(jq -c . blueprint.json)
+          JSON_BLUEPRINT=$(jq -c . blueprint.json | jq -sRr @uri)
           echo "JSON_BLUEPRINT=$JSON_BLUEPRINT" >> $GITHUB_ENV
 
       # Show final Playground URL in the Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,6 @@ jobs:
       # Show final Playground URL in the Summary
       - name: Add Playground URL to summary
         run: |
-          echo "https://playground.wordpress.net/#${BASE64_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
           echo "[Test in WP Playground](https://playground.wordpress.net/#${BASE64_BLUEPRINT})" >> $GITHUB_STEP_SUMMARY
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,16 +55,30 @@ jobs:
         run: make test
 
 
+      # Set branch name variable for blueprint URL based on event type
+      - name: Set branch name for blueprint URL
+        shell: bash
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          fi
+
       # Add test URL to workflow summary
       - name: Add test URL to summary
-        run: echo "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
+        run: echo "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/$BRANCH_NAME/blueprint.json" >> $GITHUB_STEP_SUMMARY
 
       # Create a GitHub Check Run with the test URL
       - name: Create a check with a test link
         uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{ env.BRANCH_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const branchName = process.env.BRANCH_NAME;
+            const testUrl = `https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${branchName}/blueprint.json`;
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -74,6 +88,6 @@ jobs:
               conclusion: "skipped",
               output: {
                 title: "Test in WP playground",
-                summary: "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json"
+                summary: testUrl
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,7 @@ jobs:
       - name: Run unit tests
         run: make test
 
-<<<<<<< HEAD
       # Determine the branch name
-=======
-
-      # Set branch name variable for blueprint URL based on event type
->>>>>>> 14efca43e9ed417aa68a18ae8155b60523328f4e
       - name: Set branch name for blueprint URL
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,32 +64,25 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
           fi
 
-      # Determine the branch name
-      - name: Set branch name for blueprint URL
-        shell: bash
-        run: |
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-          else
-            echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          fi
-
       # Replace main.zip with <BRANCH_NAME>.zip in blueprint.json
       - name: Patch blueprint.json with branch ZIP
         run: |
           sed -i "s|refs/heads/main.zip|refs/heads/${BRANCH_NAME}.zip|g" blueprint.json
 
-      # Convert blueprint.json to a single line
+      # Convert blueprint.json to Base64, because github not processes well json in urls
       - name: Encode blueprint for Playground
         id: blueprint
         run: |
-          JSON_BLUEPRINT=$(jq -c . blueprint.json | jq -sRr @uri)
-          echo "JSON_BLUEPRINT=$JSON_BLUEPRINT" >> $GITHUB_ENV
+          # Base64-encode the blueprint (no line wraps)
+          BASE64_BLUEPRINT=$(base64 -w 0 blueprint.json)
+          echo "BASE64_BLUEPRINT=$BASE64_BLUEPRINT" >> $GITHUB_ENV
 
       # Show final Playground URL in the Summary
       - name: Add Playground URL to summary
         run: |
-          echo "[Test in WP Playground](https://playground.wordpress.net/#${JSON_BLUEPRINT})" >> $GITHUB_STEP_SUMMARY
+          echo "https://playground.wordpress.net/#${BASE64_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
+          echo "[Test in WP Playground](https://playground.wordpress.net/#${BASE64_BLUEPRINT})" >> $GITHUB_STEP_SUMMARY
+
 
       # Create a GitHub Check Run with the Playground URL
       - name: Create a check with a test link
@@ -97,8 +90,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const jsonBlueprint = process.env.JSON_BLUEPRINT;
-            const playgroundUrl = `https://playground.wordpress.net/#${jsonBlueprint}`;
+            const encodedBlueprint = process.env.BASE64_BLUEPRINT;
+            const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -107,7 +100,9 @@ jobs:
               status: "completed",
               conclusion: "neutral",
               output: {
-                title: "Test in WP Playground",
+                title: "Test in WP playground",
                 summary: `[Test in WP Playground](${playgroundUrl})`
               }
             });
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,23 +64,32 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
           fi
 
+      # Determine the branch name
+      - name: Set branch name for blueprint URL
+        shell: bash
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          fi
+
       # Replace main.zip with <BRANCH_NAME>.zip in blueprint.json
       - name: Patch blueprint.json with branch ZIP
         run: |
           sed -i "s|refs/heads/main.zip|refs/heads/${BRANCH_NAME}.zip|g" blueprint.json
 
-      # Convert blueprint.json to Base64, then URL-encode that Base64
+      # Convert blueprint.json to a single line
       - name: Encode blueprint for Playground
         id: blueprint
         run: |
-          # Base64-encode the blueprint (no line wraps)
-          BASE64_BLUEPRINT=$(base64 -w 0 blueprint.json)
-          echo "BASE64_BLUEPRINT=$BASE64_BLUEPRINT" >> $GITHUB_ENV
+          JSON_BLUEPRINT=$(jq -c . blueprint.json)
+          echo "JSON_BLUEPRINT=$JSON_BLUEPRINT" >> $GITHUB_ENV
 
       # Show final Playground URL in the Summary
       - name: Add Playground URL to summary
         run: |
-          echo "https://playground.wordpress.net/#${BASE64_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
+          echo "[Test in WP Playground](https://playground.wordpress.net/#${JSON_BLUEPRINT})" >> $GITHUB_STEP_SUMMARY
 
       # Create a GitHub Check Run with the Playground URL
       - name: Create a check with a test link
@@ -88,8 +97,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const encodedBlueprint = process.env.BASE64_BLUEPRINT;
-            const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
+            const jsonBlueprint = process.env.JSON_BLUEPRINT;
+            const playgroundUrl = `https://playground.wordpress.net/#${jsonBlueprint}`;
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -98,7 +107,7 @@ jobs:
               status: "completed",
               conclusion: "neutral",
               output: {
-                title: "Test in WP playground",
-                summary: playgroundUrl
+                title: "Test in WP Playground",
+                summary: `[Test in WP Playground](${playgroundUrl})`
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
               name: "Test on WP playground",
               head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
               status: "completed",
-              conclusion: "success",
+              conclusion: "skipped",
               output: {
-                title: "Test Deployment Ready",
+                title: "Test in WP playground",
                 summary: "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json"
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Add test URL to workflow summary
       - name: Add test URL to summary
-        run: echo "🔗 [Test the branch here](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
+        run: echo "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)" >> $GITHUB_STEP_SUMMARY
 
       # Create a GitHub Check Run with the test URL
       - name: Create a check with a test link
@@ -68,12 +68,12 @@ jobs:
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: "Test Deployment",
+              name: "Test on WP playground",
               head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
               status: "completed",
               conclusion: "success",
               output: {
                 title: "Test Deployment Ready",
-                summary: "You can test the branch here: [Test the branch](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json)"
+                summary: "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${{ github.ref_name }}/blueprint.json"
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
       - name: Run unit tests
         run: make test
 
-
-      # Set branch name variable for blueprint URL based on event type
+      # Determine the branch name
       - name: Set branch name for blueprint URL
         shell: bash
         run: |
@@ -65,20 +64,34 @@ jobs:
             echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
           fi
 
-      # Add test URL to workflow summary
-      - name: Add test URL to summary
-        run: echo "https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/$BRANCH_NAME/blueprint.json" >> $GITHUB_STEP_SUMMARY
+      # Replace main.zip with <BRANCH_NAME>.zip in blueprint.json
+      - name: Patch blueprint.json with branch ZIP
+        run: |
+          sed -i "s|refs/heads/main.zip|refs/heads/${BRANCH_NAME}.zip|g" blueprint.json
 
-      # Create a GitHub Check Run with the test URL
+      # Convert blueprint.json to Base64, then URL-encode that Base64
+      - name: Encode blueprint for Playground
+        id: blueprint
+        run: |
+          # Base64-encode the blueprint (no line wraps)
+          BASE64_BLUEPRINT=$(base64 -w 0 blueprint.json)
+          # Then URL-encode the Base64 string
+          ENCODED_BLUEPRINT=$(echo "$BASE64_BLUEPRINT" | jq -sRr @uri)
+          echo "ENCODED_BLUEPRINT=$ENCODED_BLUEPRINT" >> $GITHUB_ENV
+
+      # Show final Playground URL in the Summary
+      - name: Add Playground URL to summary
+        run: |
+          echo "https://playground.wordpress.net/?blueprint=${ENCODED_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
+
+      # Create a GitHub Check Run with the Playground URL
       - name: Create a check with a test link
         uses: actions/github-script@v7
-        env:
-          BRANCH_NAME: ${{ env.BRANCH_NAME }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const branchName = process.env.BRANCH_NAME;
-            const testUrl = `https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/ateeducacion/wp-decker/refs/heads/${branchName}/blueprint.json`;
+            const encodedBlueprint = process.env.ENCODED_BLUEPRINT;
+            const playgroundUrl = `https://playground.wordpress.net/?blueprint=${encodedBlueprint}`;
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -88,6 +101,6 @@ jobs:
               conclusion: "neutral",
               output: {
                 title: "Test in WP playground",
-                summary: testUrl
+                summary: playgroundUrl
               }
             });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
               name: "Test on WP playground",
               head_sha: context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha,
               status: "completed",
-              conclusion: "skipped",
+              conclusion: "neutral",
               output: {
                 title: "Test in WP playground",
                 summary: testUrl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,14 +75,12 @@ jobs:
         run: |
           # Base64-encode the blueprint (no line wraps)
           BASE64_BLUEPRINT=$(base64 -w 0 blueprint.json)
-          # Then URL-encode the Base64 string
-          ENCODED_BLUEPRINT=$(echo "$BASE64_BLUEPRINT" | jq -sRr @uri)
-          echo "ENCODED_BLUEPRINT=$ENCODED_BLUEPRINT" >> $GITHUB_ENV
+          echo "BASE64_BLUEPRINT=$BASE64_BLUEPRINT" >> $GITHUB_ENV
 
       # Show final Playground URL in the Summary
       - name: Add Playground URL to summary
         run: |
-          echo "https://playground.wordpress.net/#${ENCODED_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
+          echo "https://playground.wordpress.net/#${BASE64_BLUEPRINT}" >> $GITHUB_STEP_SUMMARY
 
       # Create a GitHub Check Run with the Playground URL
       - name: Create a check with a test link
@@ -90,7 +88,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const encodedBlueprint = process.env.ENCODED_BLUEPRINT;
+            const encodedBlueprint = process.env.BASE64_BLUEPRINT;
             const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
             github.rest.checks.create({
               owner: context.repo.owner,


### PR DESCRIPTION
This pull request includes updates to the CI workflow to enhance the testing process by adding a dynamic test URL and creating a GitHub Check Run with this URL.

Enhancements to CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR56-R93): Added steps to set a branch name variable based on the event type, add a test URL to the workflow summary, and create a GitHub Check Run with the test URL.