### PR TITLE
106 improve makefile to not require local composer and php for code lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
-      - name: Run code linting
-        run: make lint
-
       - name: Install gettext
         run: sudo apt-get install -y gettext
 
@@ -47,6 +44,9 @@ jobs:
       # Start wp-env environment
       - name: Start wp-env
         run: make up
+
+      - name: Run code linting
+        run: make lint
 
       - name: Run plugin check
         run: make check-plugin

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ fix: install-phpcs
 	--colors --warning-severity=0 --extensions=php < /dev/null
 
 
-# Encuentra el contenedor CLI que levanta wp-env
+# Finds the CLI container used by wp-env
 cli-container:
 	@docker ps --format "{{.Names}}" \
 	| grep "\-cli\-" \
@@ -108,6 +108,7 @@ cli-container:
 		exit 1 \
 	)
 
+# Fix wihout tty for use on git hooks
 fix-no-tty: cli-container
 	@CONTAINER_CLI=$$( \
 		docker ps --format "{{.Names}}" \
@@ -124,6 +125,7 @@ fix-no-tty: cli-container
 		--warning-severity=0 \
 		--extensions=php
 
+# Lint wihout tty for use on git hooks
 lint-no-tty: cli-container
 	@CONTAINER_CLI=$$( \
 		docker ps --format "{{.Names}}" \

--- a/Makefile
+++ b/Makefile
@@ -87,15 +87,15 @@ install-phpcs: up
 
 # Check code style with PHP Code Sniffer inside the container
 lint: install-phpcs
-	npx wp-env run --no-TTY cli /var/www/html/wp-content/plugins/decker/vendor/bin/phpcs --standard=WordPress /var/www/html/wp-content/plugins/decker \
+	npx wp-env run cli /var/www/html/wp-content/plugins/decker/vendor/bin/phpcs --standard=WordPress /var/www/html/wp-content/plugins/decker \
 	--ignore=*/vendor/*,*/assets/*,*/node_modules/*,*/tests/js/*,*/wp/*,*/tests/* \
-	--colors --warning-severity=0 --extensions=php < /dev/null
+	--colors --warning-severity=0 --extensions=php
 
 # Automatically fix code style with PHP Code Beautifier inside the container
 fix: install-phpcs
-	npx wp-env run --no-TTY cli /var/www/html/wp-content/plugins/decker/vendor/bin/phpcbf --standard=WordPress /var/www/html/wp-content/plugins/decker \
+	npx wp-env run cli /var/www/html/wp-content/plugins/decker/vendor/bin/phpcbf --standard=WordPress /var/www/html/wp-content/plugins/decker \
 	--ignore=*/vendor/*,*/assets/*,*/node_modules/*,*/tests/js/*,*/wp/*,*/tests/* \
-	--colors --warning-severity=0 --extensions=php < /dev/null
+	--colors --warning-severity=0 --extensions=php
 
 
 # Finds the CLI container used by wp-env

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,22 @@ check-docker:
 install-requirements:
 	npm -g i @wordpress/env
 
+start-if-not-running:
+	@if [ "$$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8888)" = "000" ]; then \
+		echo "wp-env is NOT running. Starting (previous updating) containers..."; \
+		npx wp-env start --update; \
+		npx wp-env run cli wp plugin activate decker; \
+	else \
+		echo "wp-env is already running, skipping start."; \
+	fi
+
+
 # Bring up Docker containers
-up: check-docker
-	npx wp-env start
+up: check-docker start-if-not-running
+# 	npx wp-env start --update
 # 	$(MAKE) create-user USER=test1 EMAIL=test1@example.org ROLE=editor PASSWORD=password
 # 	$(MAKE) create-user USER=test2 EMAIL=test2@example.org ROLE=editor PASSWORD=password
-	npx wp-env run cli wp plugin activate decker
+# 	npx wp-env run cli wp plugin activate decker
 
 # Function to create a user only if it does not exist
 create-user:
@@ -65,17 +75,74 @@ test-verbose:
 logs:
 	npx wp-env logs
 
-# Check code style with PHP-CS-Fixer
-lint:
-	composer --no-cache phpcs --colors=always
+# Install PHP_CodeSniffer and WordPress Coding Standards in the container
+install-phpcs: up
+	@echo "Checking if PHP_CodeSniffer is installed..."
+	@if ! npx wp-env run cli /var/www/html/wp-content/plugins/decker/vendor/bin/phpcs --version > /dev/null 2>&1; then \
+		echo "Installing PHP_CodeSniffer and WordPress Coding Standards..."; \
+		npx wp-env run cli composer global require squizlabs/php_codesniffer wp-coding-standards/wpcs --no-interaction; \
+	else \
+		echo "PHP_CodeSniffer is already installed."; \
+	fi
 
-# Automatically fix code style with PHP-CS-Fixer
-fix:
-	composer --no-cache phpcbf --colors=always
+# Check code style with PHP Code Sniffer inside the container
+lint: install-phpcs
+	npx wp-env run --no-TTY cli /var/www/html/wp-content/plugins/decker/vendor/bin/phpcs --standard=WordPress /var/www/html/wp-content/plugins/decker \
+	--ignore=*/vendor/*,*/assets/*,*/node_modules/*,*/tests/js/*,*/wp/*,*/tests/* \
+	--colors --warning-severity=0 --extensions=php < /dev/null
 
-# Update wp-env and Composer dependencies
+# Automatically fix code style with PHP Code Beautifier inside the container
+fix: install-phpcs
+	npx wp-env run --no-TTY cli /var/www/html/wp-content/plugins/decker/vendor/bin/phpcbf --standard=WordPress /var/www/html/wp-content/plugins/decker \
+	--ignore=*/vendor/*,*/assets/*,*/node_modules/*,*/tests/js/*,*/wp/*,*/tests/* \
+	--colors --warning-severity=0 --extensions=php < /dev/null
+
+
+# Encuentra el contenedor CLI que levanta wp-env
+cli-container:
+	@docker ps --format "{{.Names}}" \
+	| grep "\-cli\-" \
+	| grep -v "tests-cli" \
+	|| ( \
+		echo "No main CLI container found. Please run 'make up' first." ; \
+		exit 1 \
+	)
+
+fix-no-tty: cli-container
+	@CONTAINER_CLI=$$( \
+		docker ps --format "{{.Names}}" \
+		| grep "\-cli\-" \
+		| grep -v "tests-cli" \
+	) && \
+	echo "Running PHPCBF (no TTY) inside $$CONTAINER_CLI..." && \
+	docker exec -i $$CONTAINER_CLI \
+		/var/www/html/wp-content/plugins/decker/vendor/bin/phpcbf \
+		--standard=WordPress \
+		/var/www/html/wp-content/plugins/decker \
+		--ignore=*/vendor/*,*/assets/*,*/node_modules/*,*/tests/js/*,*/wp/*,*/tests/* \
+		--colors \
+		--warning-severity=0 \
+		--extensions=php
+
+lint-no-tty: cli-container
+	@CONTAINER_CLI=$$( \
+		docker ps --format "{{.Names}}" \
+		| grep "\-cli\-" \
+		| grep -v "tests-cli" \
+	) && \
+	echo "Running PHPCS (no TTY) inside $$CONTAINER_CLI..." && \
+	docker exec -i $$CONTAINER_CLI \
+		/var/www/html/wp-content/plugins/decker/vendor/bin/phpcs \
+		--standard=WordPress \
+		/var/www/html/wp-content/plugins/decker \
+		--ignore=*/vendor/*,*/assets/*,*/node_modules/*,*/tests/js/*,*/wp/*,*/tests/* \
+		--colors \
+		--warning-severity=0 \
+		--extensions=php
+
+
+# Update Composer dependencies
 update: check-docker
-	npx wp-env start --update
 	composer update --no-cache --with-all-dependencies
 
 # Generate a .pot file for translations
@@ -126,7 +193,7 @@ help:
 	@echo "  test               - Run unit tests"
 	@echo "  check-untranslated - Check the untranslated strings"
 	@echo "  check/check-all    - Run fix, lint, check-pugin, test, check-untraslated, mo"
-	@echo "  update             - Update wp-env and Composer dependencies"
+	@echo "  update             - Update Composer dependencies"
 	@echo "  package            - Generate a .zip package"
 	@echo "  destroy            - Destroy the WordPress environment"
 	@echo "  create-user        - Create a WordPress user if it doesn't exist. Usage: make create-user USER=<username> EMAIL=<email> ROLE=<role> PASSWORD=<password>"

--- a/languages/decker-es_ES.po
+++ b/languages/decker-es_ES.po
@@ -315,7 +315,7 @@ msgstr "Adjuntos"
 
 #: includes/custom-post-types/class-decker-tasks.php:1086
 #: public/app-priority.php:170
-#: public/app-priority.php:402
+#: public/app-priority.php:408
 #: public/app-tasks.php:203
 #: public/layouts/task-card.php:199
 #, fuzzy
@@ -334,7 +334,7 @@ msgstr "Máxima Prioridad"
 #: includes/custom-post-types/class-decker-tasks.php:205
 #: includes/custom-post-types/class-decker-tasks.php:1119
 #: public/app-priority.php:171
-#: public/app-priority.php:403
+#: public/app-priority.php:409
 #: public/app-tasks.php:204
 #: public/layouts/task-card.php:245
 msgid "Stack"
@@ -600,7 +600,7 @@ msgid "Yes"
 msgstr "Sí"
 
 #: public/app-priority.php:154
-#: public/app-priority.php:392
+#: public/app-priority.php:398
 #: public/app-term-manager.php:290
 #: public/layouts/event-card.php:253
 #: public/layouts/kb-modal.php:82
@@ -615,7 +615,7 @@ msgstr "MÁXIMA PRIORIDAD"
 #: public/app-event-manager.php:63
 #: public/app-knowledge-base.php:87
 #: public/app-priority.php:172
-#: public/app-priority.php:404
+#: public/app-priority.php:410
 #: public/layouts/event-card.php:116
 #: public/layouts/event-card.php:117
 #: public/layouts/kb-modal.php:29
@@ -623,19 +623,19 @@ msgstr "MÁXIMA PRIORIDAD"
 msgid "Title"
 msgstr "Título"
 
-#: public/app-priority.php:209
+#: public/app-priority.php:215
 msgid "No board assigned"
 msgstr "Ningún tablero asignado"
 
-#: public/app-priority.php:350
+#: public/app-priority.php:356
 msgid "No tasks for today."
 msgstr "No hay tareas para hoy."
 
-#: public/app-priority.php:391
+#: public/app-priority.php:397
 msgid "Select tasks to import"
 msgstr "Seleccionar tareas para importar"
 
-#: public/app-priority.php:432
+#: public/app-priority.php:438
 msgid "There are no tasks from previous days to import."
 msgstr "No hay tareas de días anteriores para importar."
 
@@ -910,7 +910,7 @@ msgstr "Por favor, seleccione una fecha de vencimiento."
 msgid "Assign to"
 msgstr "Asignar a"
 
-#: includes/models/class-task.php:492
+#: includes/models/class-task.php:497
 #: public/layouts/task-card.php:311
 msgid "Comments"
 msgstr "Comentarios"
@@ -990,35 +990,35 @@ msgstr "Normal"
 msgid "Undefined date"
 msgstr "Fecha no definida"
 
-#: includes/models/class-task.php:454
+#: includes/models/class-task.php:459
 msgid "Order:"
 msgstr "Orden:"
 
-#: includes/models/class-task.php:545
+#: includes/models/class-task.php:550
 msgid "Edit"
 msgstr "Editar"
 
-#: includes/models/class-task.php:562
+#: includes/models/class-task.php:567
 msgid "Edit in WordPress"
 msgstr "Editar en WordPress"
 
-#: includes/models/class-task.php:569
+#: includes/models/class-task.php:574
 msgid "Archive"
 msgstr "Archivar"
 
-#: includes/models/class-task.php:578
+#: includes/models/class-task.php:583
 msgid "Assign to me"
 msgstr "Asignarme"
 
-#: includes/models/class-task.php:585
+#: includes/models/class-task.php:590
 msgid "Leave"
 msgstr "Abandonar"
 
-#: includes/models/class-task.php:600
+#: includes/models/class-task.php:605
 msgid "Mark for today"
 msgstr "Marcar para hoy"
 
-#: includes/models/class-task.php:606
+#: includes/models/class-task.php:611
 msgid "Unmark for today"
 msgstr "Desmarcar para hoy"
 

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -624,7 +624,7 @@ msgstr ""
 #: includes/custom-post-types/class-decker-tasks.php:205
 #: includes/custom-post-types/class-decker-tasks.php:1119
 #: public/app-priority.php:171
-#: public/app-priority.php:403
+#: public/app-priority.php:409
 #: public/app-tasks.php:204
 #: public/layouts/task-card.php:245
 msgid "Stack"
@@ -709,7 +709,7 @@ msgstr ""
 
 #: includes/custom-post-types/class-decker-tasks.php:1086
 #: public/app-priority.php:170
-#: public/app-priority.php:402
+#: public/app-priority.php:408
 #: public/app-tasks.php:203
 #: public/layouts/task-card.php:199
 msgid "Board"
@@ -961,40 +961,40 @@ msgstr ""
 msgid "Undefined date"
 msgstr ""
 
-#: includes/models/class-task.php:454
+#: includes/models/class-task.php:459
 msgid "Order:"
 msgstr ""
 
-#: includes/models/class-task.php:492
+#: includes/models/class-task.php:497
 #: public/layouts/task-card.php:311
 msgid "Comments"
 msgstr ""
 
-#: includes/models/class-task.php:545
+#: includes/models/class-task.php:550
 msgid "Edit"
 msgstr ""
 
-#: includes/models/class-task.php:562
+#: includes/models/class-task.php:567
 msgid "Edit in WordPress"
 msgstr ""
 
-#: includes/models/class-task.php:569
+#: includes/models/class-task.php:574
 msgid "Archive"
 msgstr ""
 
-#: includes/models/class-task.php:578
+#: includes/models/class-task.php:583
 msgid "Assign to me"
 msgstr ""
 
-#: includes/models/class-task.php:585
+#: includes/models/class-task.php:590
 msgid "Leave"
 msgstr ""
 
-#: includes/models/class-task.php:600
+#: includes/models/class-task.php:605
 msgid "Mark for today"
 msgstr ""
 
-#: includes/models/class-task.php:606
+#: includes/models/class-task.php:611
 msgid "Unmark for today"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgstr ""
 #: public/app-event-manager.php:63
 #: public/app-knowledge-base.php:87
 #: public/app-priority.php:172
-#: public/app-priority.php:404
+#: public/app-priority.php:410
 #: public/layouts/event-card.php:116
 #: public/layouts/event-card.php:117
 #: public/layouts/kb-modal.php:29
@@ -1194,7 +1194,7 @@ msgid "Yes"
 msgstr ""
 
 #: public/app-priority.php:154
-#: public/app-priority.php:392
+#: public/app-priority.php:398
 #: public/app-term-manager.php:290
 #: public/layouts/event-card.php:253
 #: public/layouts/kb-modal.php:82
@@ -1206,19 +1206,19 @@ msgstr ""
 msgid "MAX PRIORITY"
 msgstr ""
 
-#: public/app-priority.php:209
+#: public/app-priority.php:215
 msgid "No board assigned"
 msgstr ""
 
-#: public/app-priority.php:350
+#: public/app-priority.php:356
 msgid "No tasks for today."
 msgstr ""
 
-#: public/app-priority.php:391
+#: public/app-priority.php:397
 msgid "Select tasks to import"
 msgstr ""
 
-#: public/app-priority.php:432
+#: public/app-priority.php:438
 msgid "There are no tasks from previous days to import."
 msgstr ""
 


### PR DESCRIPTION
This pull request includes several changes to the CI workflow, Makefile, and translation files. The most important changes involve restructuring the CI workflow steps, improving the Makefile commands, and updating translation references.

### CI Workflow Improvements:
* Moved the code linting step in `.github/workflows/ci.yml` to occur after starting the `wp-env` environment. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL34-L36) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR48-R50)

### Makefile Enhancements:
* Added a `start-if-not-running` command to the Makefile to check if `wp-env` is already running and start it if necessary.
* Updated the `lint` and `fix` commands to install and use PHP_CodeSniffer and WordPress Coding Standards inside the container.
* Added new commands `cli-container`, `fix-no-tty`, and `lint-no-tty` for running code style checks and fixes without a TTY, useful for git hooks.
* Removed the redundant update of `wp-env` in the `update` command.

### Translation File Updates:
* Updated line references in the `languages/decker-es_ES.po` and `languages/decker.pot` files to reflect changes in the source code. [[1]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL318-R318) [[2]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL337-R337) [[3]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL603-R603) [[4]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL618-R638) [[5]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL913-R913) [[6]](diffhunk://#diff-ef307926744b03133f87aee94b7fbdc62263737376912e03db56d02ee0e5de5dL993-R1021) [[7]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L627-R627) [[8]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L712-R712) [[9]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L964-R997) [[10]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L1088-R1088) [[11]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L1197-R1197) [[12]](diffhunk://#diff-2c05ae63779d73e2e242bc35c395f69d6179ee93a5a8ed1534ca059d3b6e3ae3L1209-R1221)