### PR TITLE
Added playground url as deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
         run: |
           echo "[Test in WP Playground](https://playground.wordpress.net/#${BASE64_BLUEPRINT})" >> $GITHUB_STEP_SUMMARY
 
-
       # Create a GitHub Check Run with the Playground URL
       - name: Create a check with a test link
         uses: actions/github-script@v7
@@ -104,4 +103,33 @@ jobs:
               }
             });
 
+      # Create a deployment with the Playground URL
+      - name: Create a deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const encodedBlueprint = process.env.BASE64_BLUEPRINT;
+            const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
 
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request ? context.payload.pull_request.head.ref : context.ref,
+              required_contexts: [],
+              environment: "playground",
+              transient_environment: true,
+              auto_merge: false,
+              description: "WordPress Playground Deployment"
+            });
+
+            if (deployment.data.id) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.data.id,
+                state: "success",
+                environment_url: playgroundUrl,
+                description: "Playground environment ready"
+              });
+            }


### PR DESCRIPTION
This pull request includes changes to the continuous integration workflow in the `.github/workflows/ci.yml` file. The primary updates involve adding a new step to create a deployment with the Playground URL.

Changes to CI workflow:

* Added a new step to create a deployment with the Playground URL using `actions/github-script@v7`. This step includes creating a deployment and setting its status to success with the appropriate environment URL.

* Removed an unnecessary comment line in the existing step for creating a GitHub Check Run with the Playground URL.