### PR TITLE
Added color to the labels in task card

### DIFF
--- a/public/assets/js/task-card.js
+++ b/public/assets/js/task-card.js
@@ -246,12 +246,57 @@
         }
 
         if (context.querySelector('#task-labels')) {
-            labelsSelect = new Choices(context.querySelector('#task-labels'), { 
-                removeItemButton: true, 
-                allowHTML: true,
-                searchEnabled: true,
-                shouldSort: true,
-            });
+            // labelsSelect = new Choices(context.querySelector('#task-labels'), { 
+            //     removeItemButton: true, 
+            //     allowHTML: true,
+            //     searchEnabled: true,
+            //     shouldSort: true,
+            // });
+
+
+            labelsSelect = new Choices(context.querySelector('#task-labels'), {
+            removeItemButton: true,
+            allowHTML: true,
+            searchEnabled: true,
+            shouldSort: true,
+            callbackOnCreateTemplates: function (strToEl, escapeForTemplate, getClassNames) {
+                const defaultTemplates = Choices.defaults.templates;
+                
+
+
+                return {
+                    ...defaultTemplates,
+                    item: (classNames, data) => {
+                        // 1. Tomar el elemento que genera la plantilla por defecto
+                        const el = defaultTemplates.item.call(this, classNames, data);
+
+                        // 2. Aplicar color de fondo según la taxonomía
+                        el.style.backgroundColor = data.customProperties?.color || 'blue';
+
+                        // 3. Asegurar que, si removeItemButton=true, se configure el elemento como "deletable"
+                        if (this.config.removeItemButton) {
+                            el.setAttribute('data-deletable', '');
+
+                            // Si la plantilla por defecto no generó ya el botón, crearlo aquí
+                            if (!el.querySelector('[data-button]')) {
+                                const button = document.createElement('button');
+                                button.type = 'button';
+                                button.className = this.config.classNames.button;
+                                button.setAttribute('data-button', '');
+                                button.setAttribute('aria-label', `Remove item: ${data.value}`);
+                                button.innerHTML = '×';
+                                el.appendChild(button);
+                            }
+                        }
+
+                        return el;
+                    }
+                }
+
+            }
+        });
+
+
         }
 
         var uploadFileButton = context.querySelector('#upload-file');

--- a/public/layouts/task-card.php
+++ b/public/layouts/task-card.php
@@ -293,7 +293,7 @@ function render_comments( array $task_comments, int $parent_id, int $current_use
 				<?php
 				$labels = LabelManager::get_all_labels();
 				foreach ( $labels as $label ) {
-					echo '<option value="' . esc_attr( $label->id ) . '" data-choice-custom-properties=\'{"color": "' . esc_attr( $label->color ) . '"}\' ' . selected( in_array( $label->id, array_column( $task->labels, 'id' ) ) ) . '>' . esc_html( $label->name ) . '</option>';
+					echo '<option value="' . esc_attr( $label->id ) . '" data-custom-properties=\'{"color": "' . esc_attr( $label->color ) . '"}\' ' . selected( in_array( $label->id, array_column( $task->labels, 'id' ) ) ) . '>' . esc_html( $label->name ) . '</option>';
 				}
 				?>
 			</select>


### PR DESCRIPTION
This pull request includes changes to improve the task labels functionality in both the JavaScript and PHP files. The most important changes include adding custom templates for task labels and updating the data attribute for label options.

Improvements to task labels functionality:

* [`public/assets/js/task-card.js`](diffhunk://#diff-b5932b8da29852ed54ecf8c0dc5e47995b5a625eecee1eaa0d200c3fd2bfa04cR249-R299): Added a custom template for task labels to apply background colors based on taxonomy and ensure deletable items have a remove button.
* [`public/layouts/task-card.php`](diffhunk://#diff-c1d9060deee26f471c6ea9aeee6d75c4b8fa7cde88100bc7b3a0fdace722a726L296-R296): Updated the data attribute for label options from `data-choice-custom-properties` to `data-custom-properties` to match the new template.