### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/public/assets/js/task-card.js
+++ b/public/assets/js/task-card.js
@@ -455,14 +455,28 @@
         li.className = 'list-group-item d-flex justify-content-between align-items-center';
         li.setAttribute('data-attachment-id', attachmentId);
 
-        li.innerHTML = `
-            <a href="${attachmentUrl}" target="_blank" download="${attachmentFilename}">
-                ${attachmentFilename} <i class="bi bi-box-arrow-up-right ms-2"></i>
-            </a>
-            <div>
-                <button type="button" class="btn btn-sm btn-danger me-2 remove-attachment"${disabled ? ' disabled' : ''}>${strings.delete}</button>
-            </div>
-        `;
+        const link = document.createElement('a');
+        link.href = attachmentUrl;
+        link.target = '_blank';
+        link.download = attachmentFilename;
+        link.textContent = attachmentFilename;
+
+        const icon = document.createElement('i');
+        icon.className = 'bi bi-box-arrow-up-right ms-2';
+        link.appendChild(icon);
+
+        const buttonContainer = document.createElement('div');
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.className = 'btn btn-sm btn-danger me-2 remove-attachment';
+        if (disabled) {
+            deleteButton.disabled = true;
+        }
+        deleteButton.textContent = strings.delete;
+        buttonContainer.appendChild(deleteButton);
+
+        li.appendChild(link);
+        li.appendChild(buttonContainer);
 
         attachmentsList.appendChild(li);
 


### PR DESCRIPTION
Potential fix for [https://github.com/ateeducacion/wp-decker/security/code-scanning/5](https://github.com/ateeducacion/wp-decker/security/code-scanning/5)

To fix the issue, we need to ensure that any user-controlled data interpolated into the HTML is properly escaped to prevent XSS. The best approach is to use a DOM manipulation method (e.g., `textContent` or `createTextNode`) to safely insert text into the DOM instead of using `innerHTML`. Specifically, we will:

1. Replace the use of `innerHTML` on line 458 with a safer approach that constructs the DOM elements programmatically.
2. Use `textContent` to safely set the text content of the filename and avoid interpreting it as HTML.

This change ensures that any special characters in the file name (e.g., `<`, `>`, `&`) are treated as plain text and not as HTML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
