### PR TITLE
Fixed version for wordpress plugin directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,9 @@ jobs:
 
       - name: Set environment variables
         run: |
-          echo "RELEASE_TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
+          RAW_TAG="${GITHUB_REF##*/}"
+          VERSION_TAG="${RAW_TAG#v}"  # Delete the initial 'v' if exists
+          echo "RELEASE_TAG=${VERSION_TAG}" >> $GITHUB_ENV
 
       - name: Create package using the Makefile
         run: make package VERSION=${RELEASE_TAG}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,8 @@ stages:
 variables:
   # Package version should match \A(\.?[\w\+-]+\.?)+\z regular expresion.
   # See https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
-  PACKAGE_VERSION: "${CI_COMMIT_TAG}"
+  # Strip leading 'v' from tag, so 'v2.2.2' → '2.2.2'
+  PACKAGE_VERSION: "${CI_COMMIT_TAG#v}"
   PACKAGE_BINARY: "decker-${PACKAGE_VERSION}"
   PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/decker/${PACKAGE_VERSION}"
 
@@ -60,7 +61,7 @@ release:
         - name: "${PACKAGE_BINARY}.zip"
           # Disabled build and upload stages until get internet connection on Gitlab Runner
           # url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
-          url: "https://github.com/ateeducacion/wp-decker/releases/download/${PACKAGE_VERSION}/${PACKAGE_BINARY}.zip"
+          url: "https://github.com/ateeducacion/wp-decker/releases/download/${CI_COMMIT_TAG}/${PACKAGE_BINARY}.zip"
 
 
 sonarqube-check:


### PR DESCRIPTION
This pull request introduces changes to streamline the handling of version tags in CI workflows by stripping the leading 'v' from version tags where applicable. Additionally, it updates a URL in the GitLab CI configuration to use the unmodified tag instead of the stripped version.

### Updates to version tag handling:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L20-R22): Modified the `Set environment variables` step to strip the leading 'v' from the `GITHUB_REF` tag before assigning it to the `RELEASE_TAG` environment variable.
* [`.gitlab-ci.yml`](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L12-R13): Updated the `PACKAGE_VERSION` variable to strip the leading 'v' from `CI_COMMIT_TAG` for consistent version formatting.

### URL update in GitLab CI:

* [`.gitlab-ci.yml`](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L63-R64): Changed the `release` stage to use the original `CI_COMMIT_TAG` in the download URL instead of the stripped `PACKAGE_VERSION`.