### PR TITLE
Hotfix/json change board

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,44 +22,6 @@ jobs:
       # Checkout the code
       - uses: actions/checkout@v4
 
-      - name: Pre-pull Docker images
-        run: |
-          docker pull mariadb:lts
-          docker pull wordpress
-          docker pull wordpress:cli
-
-      - name: PHP setup
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'  # Adjust the version according to your needs
-          extensions: mbstring, intl, curl, dom, json, pdo, mysql, xml, zip
-
-      - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
-
-      - name: Install gettext
-        run: sudo apt-get install -y gettext
-
-      - name: Check untranslated strings
-        run: make check-untranslated
-
-      # Install wp-env globally
-      - name: Setup wp-env
-        run: npm -g --no-fund i @wordpress/env
-
-      # Start wp-env environment
-      - name: Start wp-env
-        run: make up
-
-      - name: Run code linting
-        run: make lint
-
-      - name: Run plugin check
-        run: make check-plugin
-
-      - name: Run unit tests
-        run: make test
-
       # Determine the branch name
       - name: Set branch name for blueprint URL
         shell: bash
@@ -139,4 +101,45 @@ jobs:
                 description: "Playground environment ready"
               });
             }
+
+
+
+      - name: Pre-pull Docker images
+        run: |
+          docker pull mariadb:lts
+          docker pull wordpress
+          docker pull wordpress:cli
+
+      - name: PHP setup
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'  # Adjust the version according to your needs
+          extensions: mbstring, intl, curl, dom, json, pdo, mysql, xml, zip
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install gettext
+        run: sudo apt-get install -y gettext
+
+      - name: Check untranslated strings
+        run: make check-untranslated
+
+      # Install wp-env globally
+      - name: Setup wp-env
+        run: npm -g --no-fund i @wordpress/env
+
+      # Start wp-env environment
+      - name: Start wp-env
+        run: make up
+
+      - name: Run code linting
+        run: make lint
+
+      - name: Run plugin check
+        run: make check-plugin
+
+      - name: Run unit tests
+        run: make test
+
 

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -552,13 +552,13 @@ class Decker_Tasks {
 				'permission_callback' => function () {
 					return current_user_can( 'read' );
 				},
-				'args' => [
-			        'board_id'      => [ 'required' => true ],
-			        'source_stack'  => [ 'required' => true ],
-			        'target_stack'  => [ 'required' => true ],
-			        'source_order'  => [ 'required' => true ],
-			        'target_order'  => [ 'required' => true ],
-			    ]				
+				'args' => array(
+					'board_id'      => array( 'required' => true ),
+					'source_stack'  => array( 'required' => true ),
+					'target_stack'  => array( 'required' => true ),
+					'source_order'  => array( 'required' => true ),
+					'target_order'  => array( 'required' => true ),
+				),
 			)
 		);
 
@@ -571,13 +571,13 @@ class Decker_Tasks {
 				'permission_callback' => function () {
 					return current_user_can( 'read' );
 				},
-				'args' => [
-			        'board_id'      => [ 'required' => true ],
-			        'source_stack'  => [ 'required' => true ],
-			        'target_stack'  => [ 'required' => true ],
-			        'source_order'  => [ 'required' => true ],
-			        'target_order'  => [ 'required' => true ],
-			    ]
+				'args' => array(
+					'board_id'      => array( 'required' => true ),
+					'source_stack'  => array( 'required' => true ),
+					'target_stack'  => array( 'required' => true ),
+					'source_order'  => array( 'required' => true ),
+					'target_order'  => array( 'required' => true ),
+				),
 			)
 		);
 

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -459,7 +459,7 @@ class Decker_Tasks {
 			$this->reorder_tasks_in_stack( $board_term_id, $stack, $post_id );
 		}
 
-		do_action( 'decker_task_updated', $post_id ); // Invalidates .ics “all”.
+		// do_action( 'decker_task_updated', $post_id ); // Invalidates .ics “all”.
 	}
 
 	/**
@@ -876,7 +876,7 @@ class Decker_Tasks {
 			}
 		}
 
-		do_action( 'decker_task_updated', $task_id ); // Invalidates .ics “all”.
+		// do_action( 'decker_task_updated', $task_id ); // Invalidates .ics “all”.
 
 		 // Step 4: Return response.
 		return new WP_REST_Response(

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -253,11 +253,12 @@ class Decker_Tasks {
 	 */
 	public function update_task_stack_and_order( $request ) {
 		$task_id      = intval( $request['id'] );
-		$board_id     = intval( $request->get_param( 'board_id' ) );
-		$source_stack = sanitize_text_field( $request->get_param( 'source_stack' ) );
-		$target_stack = sanitize_text_field( $request->get_param( 'target_stack' ) );
-		$source_order = intval( $request->get_param( 'source_order' ) );
-		$target_order = intval( $request->get_param( 'target_order' ) );
+		$params       = $request->get_json_params();
+		$board_id     = intval( $params['board_id'] ?? 0 );
+		$source_stack = sanitize_text_field( $params['source_stack'] ?? '' );
+		$target_stack = sanitize_text_field( $params['target_stack'] ?? '' );
+		$source_order = intval( $params['source_order'] ?? 0 );
+		$target_order = intval( $params['target_order'] ?? 0 );
 
 		$valid_stacks = array( 'to-do', 'in-progress', 'done' );
 

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -253,12 +253,11 @@ class Decker_Tasks {
 	 */
 	public function update_task_stack_and_order( $request ) {
 		$task_id      = intval( $request['id'] );
-		$params       = $request->get_json_params();
-		$board_id     = intval( $params['board_id'] ?? 0 );
-		$source_stack = sanitize_text_field( $params['source_stack'] ?? '' );
-		$target_stack = sanitize_text_field( $params['target_stack'] ?? '' );
-		$source_order = intval( $params['source_order'] ?? 0 );
-		$target_order = intval( $params['target_order'] ?? 0 );
+		$board_id     = intval( $request->get_param( 'board_id' ) );
+		$source_stack = sanitize_text_field( $request->get_param( 'source_stack' ) );
+		$target_stack = sanitize_text_field( $request->get_param( 'target_stack' ) );
+		$source_order = intval( $request->get_param( 'source_order' ) );
+		$target_order = intval( $request->get_param( 'target_order' ) );
 
 		$valid_stacks = array( 'to-do', 'in-progress', 'done' );
 

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -254,12 +254,22 @@ class Decker_Tasks {
 	public function update_task_stack_and_order( $request ) {
 		$task_id      = intval( $request['id'] );
 
-		$params       = $request->get_json_params();
-		$board_id     = intval( $params['board_id'] ?? intval( $request->get_param( 'board_id' ) ) );
-		$source_stack = sanitize_text_field( $params['source_stack'] ?? $request->get_param( 'source_stack' ) );
-		$target_stack = sanitize_text_field( $params['target_stack'] ?? $request->get_param( 'target_stack' ) );
-		$source_order = intval( $params['source_order'] ?? $request->get_param( 'source_order' ) );
-		$target_order = intval( $params['target_order'] ?? $request->get_param( 'target_order' ) );
+
+		$params = $request->get_json_params();
+		$board_id = isset($params['board_id']) ? intval($params['board_id']) : intval( $request->get_param( 'board_id' ) );
+		$source_stack = isset($params['source_stack']) ? sanitize_text_field($params['source_stack']) : sanitize_text_field( $request->get_param( 'source_stack' ) );
+		$target_stack = isset($params['target_stack']) ? sanitize_text_field($params['target_stack']) : sanitize_text_field( $request->get_param( 'target_stack' ) );
+		$source_order = isset($params['source_order']) ? intval($params['source_order']) : intval( $request->get_param( 'source_order' ) );
+		$target_order = isset($params['target_order']) ? intval($params['target_order']) : intval( $request->get_param( 'target_order' ) );
+
+
+
+		// $params       = $request->get_json_params();
+		// $board_id     = intval( $params['board_id'] ?? intval( $request->get_param( 'board_id' ) ) );
+		// $source_stack = sanitize_text_field( $params['source_stack'] ?? $request->get_param( 'source_stack' ) );
+		// $target_stack = sanitize_text_field( $params['target_stack'] ?? $request->get_param( 'target_stack' ) );
+		// $source_order = intval( $params['source_order'] ?? $request->get_param( 'source_order' ) );
+		// $target_order = intval( $params['target_order'] ?? $request->get_param( 'target_order' ) );
 
 		error_log( 'SOURCE: ' . $source_stack );
 		error_log( 'TARGET: ' . $target_stack );
@@ -270,6 +280,14 @@ class Decker_Tasks {
 		error_log( 'target_stack: ' . $request->get_param( 'target_stack' ) );
 		error_log( 'source_order: ' . $request->get_param( 'source_order' ) );
 		error_log( 'target_order: ' . $request->get_param( 'target_order' ) );
+		
+		error_log('BODY RAW: ' . file_get_contents('php://input'));
+
+
+		error_log( '[REQUEST - get_body] ' . $request->get_body() );
+		error_log( '[REQUEST - get_params] ' . print_r( $request->get_params(), true ) );
+		error_log( '[REQUEST - get_json_params] ' . print_r( $request->get_json_params(), true ) );
+		error_log( '[REQUEST - all headers] ' . print_r( $request->get_headers(), true ) );
 
 
 		error_log( print_r( $request->get_json_params(), true ) );

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -599,6 +599,13 @@ class Decker_Tasks {
 				'permission_callback' => function () {
 					return current_user_can( 'read' );
 				},
+				'args' => [
+			        'board_id'      => [ 'required' => true ],
+			        'source_stack'  => [ 'required' => true ],
+			        'target_stack'  => [ 'required' => true ],
+			        'source_order'  => [ 'required' => true ],
+			        'target_order'  => [ 'required' => true ],
+			    ]
 			)
 		);
 

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -264,6 +264,17 @@ class Decker_Tasks {
 		error_log( 'SOURCE: ' . $source_stack );
 		error_log( 'TARGET: ' . $target_stack );
 
+		error_log( 'task_id: ' . $request->get_param( 'id' ) );
+		error_log( 'board_id: ' . $request->get_param( 'board_id' ) );
+		error_log( 'source_stack: ' . $request->get_param( 'source_stack' ) );
+		error_log( 'target_stack: ' . $request->get_param( 'target_stack' ) );
+		error_log( 'source_order: ' . $request->get_param( 'source_order' ) );
+		error_log( 'target_order: ' . $request->get_param( 'target_order' ) );
+
+
+		error_log( print_r( $request->get_json_params(), true ) );
+		error_log( print_r( $request->get_params(), true ) );
+
 
 		$valid_stacks = array( 'to-do', 'in-progress', 'done' );
 

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -258,8 +258,8 @@ class Decker_Tasks {
 		$board_id     = intval( $params['board_id'] ?? intval( $request->get_param( 'board_id' ) ) );
 		$source_stack = sanitize_text_field( $params['source_stack'] ?? $request->get_param( 'source_stack' ) );
 		$target_stack = sanitize_text_field( $params['target_stack'] ?? $request->get_param( 'target_stack' ) );
-		$source_order = intval( $params['source_order'] ?? $request->get_param( 'source_order'  );
-		$target_order = intval( $params['target_order'] ?? $request->get_param( 'target_order'  );
+		$source_order = intval( $params['source_order'] ?? $request->get_param( 'source_order' ) );
+		$target_order = intval( $params['target_order'] ?? $request->get_param( 'target_order' ) );
 
 		error_log( 'SOURCE: ' . $source_stack );
 		error_log( 'TARGET: ' . $target_stack );

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -253,46 +253,11 @@ class Decker_Tasks {
 	 */
 	public function update_task_stack_and_order( $request ) {
 		$task_id      = intval( $request['id'] );
-
-
-		$params = $request->get_json_params();
-		$board_id = isset($params['board_id']) ? intval($params['board_id']) : intval( $request->get_param( 'board_id' ) );
-		$source_stack = isset($params['source_stack']) ? sanitize_text_field($params['source_stack']) : sanitize_text_field( $request->get_param( 'source_stack' ) );
-		$target_stack = isset($params['target_stack']) ? sanitize_text_field($params['target_stack']) : sanitize_text_field( $request->get_param( 'target_stack' ) );
-		$source_order = isset($params['source_order']) ? intval($params['source_order']) : intval( $request->get_param( 'source_order' ) );
-		$target_order = isset($params['target_order']) ? intval($params['target_order']) : intval( $request->get_param( 'target_order' ) );
-
-
-
-		// $params       = $request->get_json_params();
-		// $board_id     = intval( $params['board_id'] ?? intval( $request->get_param( 'board_id' ) ) );
-		// $source_stack = sanitize_text_field( $params['source_stack'] ?? $request->get_param( 'source_stack' ) );
-		// $target_stack = sanitize_text_field( $params['target_stack'] ?? $request->get_param( 'target_stack' ) );
-		// $source_order = intval( $params['source_order'] ?? $request->get_param( 'source_order' ) );
-		// $target_order = intval( $params['target_order'] ?? $request->get_param( 'target_order' ) );
-
-		error_log( 'SOURCE: ' . $source_stack );
-		error_log( 'TARGET: ' . $target_stack );
-
-		error_log( 'task_id: ' . $request->get_param( 'id' ) );
-		error_log( 'board_id: ' . $request->get_param( 'board_id' ) );
-		error_log( 'source_stack: ' . $request->get_param( 'source_stack' ) );
-		error_log( 'target_stack: ' . $request->get_param( 'target_stack' ) );
-		error_log( 'source_order: ' . $request->get_param( 'source_order' ) );
-		error_log( 'target_order: ' . $request->get_param( 'target_order' ) );
-		
-		error_log('BODY RAW: ' . file_get_contents('php://input'));
-
-
-		error_log( '[REQUEST - get_body] ' . $request->get_body() );
-		error_log( '[REQUEST - get_params] ' . print_r( $request->get_params(), true ) );
-		error_log( '[REQUEST - get_json_params] ' . print_r( $request->get_json_params(), true ) );
-		error_log( '[REQUEST - all headers] ' . print_r( $request->get_headers(), true ) );
-
-
-		error_log( print_r( $request->get_json_params(), true ) );
-		error_log( print_r( $request->get_params(), true ) );
-
+		$board_id     = intval( $request->get_param( 'board_id' ) );
+		$source_stack = sanitize_text_field( $request->get_param( 'source_stack' ) );
+		$target_stack = sanitize_text_field( $request->get_param( 'target_stack' ) );
+		$source_order = intval( $request->get_param( 'source_order' ) );
+		$target_order = intval( $request->get_param( 'target_order' ) );
 
 		$valid_stacks = array( 'to-do', 'in-progress', 'done' );
 
@@ -459,7 +424,7 @@ class Decker_Tasks {
 			$this->reorder_tasks_in_stack( $board_term_id, $stack, $post_id );
 		}
 
-		// do_action( 'decker_task_updated', $post_id ); // Invalidates .ics “all”.
+		do_action( 'decker_task_updated', $post_id ); // Invalidates .ics “all”.
 	}
 
 	/**
@@ -587,6 +552,13 @@ class Decker_Tasks {
 				'permission_callback' => function () {
 					return current_user_can( 'read' );
 				},
+				'args' => [
+			        'board_id'      => [ 'required' => true ],
+			        'source_stack'  => [ 'required' => true ],
+			        'target_stack'  => [ 'required' => true ],
+			        'source_order'  => [ 'required' => true ],
+			        'target_order'  => [ 'required' => true ],
+			    ]				
 			)
 		);
 
@@ -876,7 +848,7 @@ class Decker_Tasks {
 			}
 		}
 
-		// do_action( 'decker_task_updated', $task_id ); // Invalidates .ics “all”.
+		do_action( 'decker_task_updated', $task_id ); // Invalidates .ics “all”.
 
 		 // Step 4: Return response.
 		return new WP_REST_Response(

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -253,16 +253,19 @@ class Decker_Tasks {
 	 */
 	public function update_task_stack_and_order( $request ) {
 		$task_id      = intval( $request['id'] );
-		$board_id     = intval( $request->get_param( 'board_id' ) );
-		$source_stack = sanitize_text_field( $request->get_param( 'source_stack' ) );
-		$target_stack = sanitize_text_field( $request->get_param( 'target_stack' ) );
-		$source_order = intval( $request->get_param( 'source_order' ) );
-		$target_order = intval( $request->get_param( 'target_order' ) );
 
-		$valid_stacks = array( 'to-do', 'in-progress', 'done' );
+		$params       = $request->get_json_params();
+		$board_id     = intval( $params['board_id'] ?? intval( $request->get_param( 'board_id' ) ) );
+		$source_stack = sanitize_text_field( $params['source_stack'] ?? $request->get_param( 'source_stack' ) );
+		$target_stack = sanitize_text_field( $params['target_stack'] ?? $request->get_param( 'target_stack' ) );
+		$source_order = intval( $params['source_order'] ?? $request->get_param( 'source_order'  );
+		$target_order = intval( $params['target_order'] ?? $request->get_param( 'target_order'  );
 
 		error_log( 'SOURCE: ' . $source_stack );
 		error_log( 'TARGET: ' . $target_stack );
+
+
+		$valid_stacks = array( 'to-do', 'in-progress', 'done' );
 
 		if ( ! in_array( $source_stack, $valid_stacks ) || ! in_array( $target_stack, $valid_stacks ) ) {
 			return new WP_REST_Response(

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -261,6 +261,9 @@ class Decker_Tasks {
 
 		$valid_stacks = array( 'to-do', 'in-progress', 'done' );
 
+		error_log( 'SOURCE: ' . $source_stack );
+		error_log( 'TARGET: ' . $target_stack );
+
 		if ( ! in_array( $source_stack, $valid_stacks ) || ! in_array( $target_stack, $valid_stacks ) ) {
 			return new WP_REST_Response(
 				array(


### PR DESCRIPTION
This pull request includes changes to standardize the syntax for defining REST route arguments in the `register_rest_routes` method of the `class-decker-tasks.php` file. The changes replace array shorthand syntax with the full `array()` syntax for better consistency and compatibility.

### Syntax Standardization:

* Updated the `args` definition in the first REST route to use `array()` instead of shorthand `[]` syntax. (`[includes/custom-post-types/class-decker-tasks.phpL555-R561](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5L555-R561)`)
* Updated the `args` definition in the second REST route to use `array()` instead of shorthand `[]` syntax. (`[includes/custom-post-types/class-decker-tasks.phpL574-R580](diffhunk://#diff-f26628552a52404f55a0bcfff0dfad8929dd70c011896d4c2deaac95908379d5L574-R580)`)