### PR TITLE
155 preserve user filters in upcoming tasks view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,11 @@ start-if-not-running:
 	fi
 
 # Bring up Docker containers
-up: check-docker start-if-not-running flush-permalinks
+up: check-docker start-if-not-running
 
 flush-permalinks:
-	npx wp-env run cli wp rewrite flush --hard
+	#npx wp-env run cli wp rewrite flush --hard
+	npx wp-env run cli wp rewrite structure '/%postname%/'
 
 # Function to create a user only if it does not exist
 create-user:

--- a/public/app-kanban.php
+++ b/public/app-kanban.php
@@ -317,9 +317,39 @@ function() {
 		</script>
 
 		<script>
+			// Function to update URL with filter parameters
+			function updateUrlWithUserFilter(user) {
+				const url = new URL(window.location);
+				if (user) {
+					url.searchParams.set('user', user);
+				} else {
+					url.searchParams.delete('user');
+				}
+				window.history.replaceState(null, '', url);
+				
+				// Save to localStorage for persistence across sessions
+				if (user) {
+					localStorage.setItem('kanban_user_filter', user);
+				} else {
+					localStorage.removeItem('kanban_user_filter');
+				}
+			}
+
+			// Function to get URL parameters
+			function getUrlParam(name) {
+				const urlParams = new URLSearchParams(window.location.search);
+				return urlParams.get(name);
+			}
+
 			document.addEventListener('DOMContentLoaded', function () {
 				const searchInput = document.getElementById('searchInput');
 				const boardUserFilter = document.getElementById('boardUserFilter');
+				
+				// Get initial user filter from URL or localStorage
+				const initialUser = getUrlParam('user') || localStorage.getItem('kanban_user_filter');
+				if (initialUser) {
+					boardUserFilter.value = initialUser;
+				}
 
 				function filterTasks() {
 					const searchText = searchInput.value.toLowerCase();
@@ -340,8 +370,16 @@ function() {
 					});
 				}
 
+				// Event listeners
 				searchInput.addEventListener('input', filterTasks);
-				boardUserFilter.addEventListener('change', filterTasks);
+				boardUserFilter.addEventListener('change', function() {
+					const selectedUser = this.value;
+					updateUrlWithUserFilter(selectedUser);
+					filterTasks();
+				});
+				
+				// Apply initial filter
+				filterTasks();
 			});
 		</script>
 

--- a/public/app-kanban.php
+++ b/public/app-kanban.php
@@ -327,12 +327,6 @@ function() {
 				}
 				window.history.replaceState(null, '', url);
 				
-				// Save to localStorage for persistence across sessions
-				if (user) {
-					localStorage.setItem('kanban_user_filter', user);
-				} else {
-					localStorage.removeItem('kanban_user_filter');
-				}
 			}
 
 			// Function to get URL parameters
@@ -345,8 +339,8 @@ function() {
 				const searchInput = document.getElementById('searchInput');
 				const boardUserFilter = document.getElementById('boardUserFilter');
 				
-				// Get initial user filter from URL or localStorage
-				const initialUser = getUrlParam('user') || localStorage.getItem('kanban_user_filter');
+				// Get initial user filter from URL
+				const initialUser = getUrlParam('user');
 				if (initialUser) {
 					boardUserFilter.value = initialUser;
 				}

--- a/public/app-tasks.php
+++ b/public/app-tasks.php
@@ -362,7 +362,7 @@ table#tablaTareas td:nth-child(4) {
 	// Set locale to Spanish
 	// dayjs.locale('es');
 
-	function setupAllTasksTable() {
+	function setupAllTasksTable(initialBoard) {
 		if (!jQuery.fn.DataTable.isDataTable('#tablaTareas')) {
 			// Initialize DataTables only if it hasn't been initialized yet
 			tablaElement = jQuery('#tablaTareas').DataTable({
@@ -434,19 +434,53 @@ table#tablaTareas td:nth-child(4) {
 					// Move SearchBuilder to the desired location
 					var searchBuilderButton = jQuery('.dt-buttons .dt-button');
 					jQuery('#searchBuilderContainer').append(searchBuilderButton);
+					
+					// Aplicar filtro inicial si existe
+					if (initialBoard) {
+						tablaElement.column(1).search(initialBoard).draw();
+					}
 				}
 			});
 
 			// Filter by board using combobox
 			jQuery('#boardFilter').on('change', function () {
-				tablaElement.column(1).search(this.value).draw();
+				const boardValue = this.value;
+				tablaElement.column(1).search(boardValue).draw();
+				// Actualizar URL con el nuevo filtro
+				updateUrlWithFilters(boardValue);
 			});
 		}
 	}
 
+	// Función para actualizar la URL con los parámetros de filtro
+	function updateUrlWithFilters(boardFilter) {
+		const url = new URL(window.location);
+		if (boardFilter) {
+			url.searchParams.set('board', boardFilter);
+		} else {
+			url.searchParams.delete('board');
+		}
+		window.history.replaceState(null, '', url);
+	}
+
+	// Función para leer parámetros de la URL
+	function getUrlParam(name) {
+		const urlParams = new URLSearchParams(window.location.search);
+		return urlParams.get(name);
+	}
+
 	// Call setup function when document is ready
 	jQuery(document).ready(function () {
-		setupAllTasksTable();
+		// Leer parámetros de la URL
+		const initialBoard = getUrlParam('board');
+		
+		setupAllTasksTable(initialBoard);
+
+		// Si hay un filtro de tablero en la URL, aplicarlo
+		if (initialBoard) {
+			jQuery('#boardFilter').val(initialBoard);
+		}
+
 		// Manejar el evento de clic en el checkbox "Today"
 		document.querySelectorAll('.today-checkbox').forEach(checkbox => {
 			checkbox.addEventListener('change', function() {


### PR DESCRIPTION
This pull request introduces updates to improve URL-based filtering and task management in the Kanban and Tasks applications, as well as a minor change in the `Makefile`. The key changes include adding URL parameter handling for filters, applying initial filters based on URL parameters, and modifying the `Makefile` to adjust Docker-related commands.

### Enhancements to URL-based filtering:

* `public/app-kanban.php`:
  - Added functions `updateUrlWithUserFilter` and `getUrlParam` to manage URL parameters for user filters. These functions allow updating and retrieving the `user` parameter from the URL.
  - Updated the `filterTasks` function to apply an initial user filter based on the URL and synchronize the URL with filter changes.

* `public/app-tasks.php`:
  - Modified `setupAllTasksTable` to accept an `initialBoard` parameter and apply an initial board filter based on the URL. [[1]](diffhunk://#diff-7e95dad0e9c21bc51289899570d473a35e438d401e90498b793b0152053913c0L365-R365) [[2]](diffhunk://#diff-7e95dad0e9c21bc51289899570d473a35e438d401e90498b793b0152053913c0R437-R483)
  - Added functions `updateUrlWithFilters` and `getUrlParam` to manage URL parameters for board filters. These functions update the URL when the board filter changes and retrieve the `board` parameter from the URL.

### Updates to Docker commands:

* `Makefile`:
  - Removed the `flush-permalinks` step from the `up` target and replaced it with a new permalink structure command. This change comments out the previous flush command and sets a custom permalink structure.