### PR TITLE
feat: Persistir vista preferida del calendario en localStorage

### DIFF
--- a/public/assets/js/event-calendar.js
+++ b/public/assets/js/event-calendar.js
@@ -105,6 +105,17 @@ function showTooltip(message, duration = 2000){
                 const browserTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
                 const fcLocale = (deckerVars.locale || 'en').toLowerCase();
 
+                // Compute initial view from URL or localStorage
+                const urlParams = new URLSearchParams(window.location.search);
+                let initialView = urlParams.get('view');
+                const validViews = ['dayGridMonth', 'timeGridWeek', 'timeGridDay', 'listMonth'];
+                if (!validViews.includes(initialView)) {
+                    initialView = localStorage.getItem('deckerCalendarView');
+                    if (!validViews.includes(initialView)) {
+                        initialView = 'dayGridMonth'; // default
+                    }
+                }
+
 
                 this.$calendarObj = new FullCalendar.Calendar(this.$calendar[0], {
                     timeZone: 'local',
@@ -133,7 +144,7 @@ function showTooltip(message, duration = 2000){
                         prev: '<',
                         next: '>',
                     },
-                    initialView: 'dayGridMonth',
+                    initialView: initialView,
                     handleWindowResize: true,
                     height: $(window).height() - 200,
                     dayMaxEvents: 4,
@@ -354,6 +365,10 @@ function showTooltip(message, duration = 2000){
 
                         }
                         titleEl.setAttribute('title', info.event.title);
+                    },
+                    viewDidMount: function(info) {
+                        const currentView = info.view.type;
+                        localStorage.setItem('deckerCalendarView', currentView);
                     }
                 });
 


### PR DESCRIPTION
This pull request enhances the `event-calendar.js` functionality by introducing dynamic handling of the calendar's initial view and persisting the user's preferred view across sessions. The changes aim to improve user experience by making the calendar more intuitive and personalized.

### Enhancements to calendar view handling:

* **Dynamic initial view determination**:
  - The calendar now computes its initial view based on URL parameters or falls back to a value stored in `localStorage`. If neither is valid, it defaults to `'dayGridMonth'`. This ensures the calendar adapts to user preferences or external links. (`[public/assets/js/event-calendar.jsR108-R118](diffhunk://#diff-37a26e0c95e5b19babdd0c40b7f5b7e6e086be81543a54586214b04295d0f256R108-R118)`)
  - Updated the `initialView` configuration to use the dynamically computed value instead of a hardcoded default. (`[public/assets/js/event-calendar.jsL136-R147](diffhunk://#diff-37a26e0c95e5b19babdd0c40b7f5b7e6e086be81543a54586214b04295d0f256L136-R147)`)

* **Persistence of user-selected view**:
  - Added a `viewDidMount` callback to save the currently selected calendar view to `localStorage` whenever the view changes. This allows the calendar to remember the user's last selected view for future visits. (`[public/assets/js/event-calendar.jsR368-R371](diffhunk://#diff-37a26e0c95e5b19babdd0c40b7f5b7e6e086be81543a54586214b04295d0f256R368-R371)`)