### PR TITLE
feat: Add demo data for easier gantt testing

### DIFF
--- a/includes/class-decker-demo-data.php
+++ b/includes/class-decker-demo-data.php
@@ -530,7 +530,7 @@ class Decker_Demo_Data {
 					$stack,
 					$board_id,
 					$max_priority,
-					$end_date, // due date is end of task
+					$end_date, // due date is end of task.
 					1,
 					1,
 					false,
@@ -542,21 +542,24 @@ class Decker_Demo_Data {
 				);
 
 				if ( $task_id && ! is_wp_error( $task_id ) ) {
-					// Generate user-date relations for each day in the task duration
+					// Generate user-date relations for each day in the task duration.
 					$relations = array();
 					$period_start = clone $start_date;
 					$period_end = clone $end_date;
-					$period_end->modify( '+1 day' ); // to include end date
+					$period_end->modify( '+1 day' ); // to include end date.
 
 					$interval = new DateInterval( 'P1D' );
 					$period = new DatePeriod( $period_start, $interval, $period_end );
 
 					foreach ( $period as $day ) {
 						foreach ( $assigned_users as $user_id ) {
-							$relations[] = array(
-								'user_id' => $user_id,
-								'date'    => $day->format( 'Y-m-d' ),
-							);
+							// 60% chance to create a relation.
+							if ( $this->random_boolean( 0.6 ) ) {
+								$relations[] = array(
+									'user_id' => $user_id,
+									'date'    => $day->format( 'Y-m-d' ),
+								);
+							}
 						}
 					}
 

--- a/includes/class-decker-demo-data.php
+++ b/includes/class-decker-demo-data.php
@@ -553,8 +553,11 @@ class Decker_Demo_Data {
 
 					foreach ( $period as $day ) {
 						foreach ( $assigned_users as $user_id ) {
-							// 70% chance to create a relation.
-							if ( $this->random_boolean( 0.7 ) ) {
+							$dates = iterator_to_array( $period );
+							$days_to_assign = $this->custom_rand( 1, count( $dates ) );
+							$random_dates = $this->wp_rand_elements( $dates, $days_to_assign );
+
+							foreach ( $random_dates as $day ) {
 								$relations[] = array(
 									'user_id' => $user_id,
 									'date'    => $day->format( 'Y-m-d' ),

--- a/includes/class-decker-demo-data.php
+++ b/includes/class-decker-demo-data.php
@@ -553,8 +553,8 @@ class Decker_Demo_Data {
 
 					foreach ( $period as $day ) {
 						foreach ( $assigned_users as $user_id ) {
-							// 60% chance to create a relation.
-							if ( $this->random_boolean( 0.6 ) ) {
+							// 70% chance to create a relation.
+							if ( $this->random_boolean( 0.7 ) ) {
 								$relations[] = array(
 									'user_id' => $user_id,
 									'date'    => $day->format( 'Y-m-d' ),


### PR DESCRIPTION
This pull request introduces enhancements to the `create_tasks` function in `includes/class-decker-demo-data.php` to improve task date handling and add user-date relations. The most important changes include replacing the `due_date` with a calculated `start_date` and `end_date`, and adding functionality to generate and store user-date relations for the task duration.

### Enhancements to task date handling:
* Replaced the `due_date` with a `start_date` and `end_date`, where the `end_date` is calculated based on a random duration (1-14 days) added to the `start_date`. The `end_date` is now passed as the due date when creating or updating a task. (`[includes/class-decker-demo-data.phpL520-R533](diffhunk://#diff-54230d7f950949036ad92a8d71bdc5569f2165679973d38ea0600fa87b85ed4bL520-R533)`)

### Addition of user-date relations:
* Added logic to generate user-date relations for each day within the task's duration. These relations are stored in the task's metadata (`_user_date_relations`) along with the `start_date`. This ensures better tracking of user assignments over the task's timeline. (`[includes/class-decker-demo-data.phpR543-R565](diffhunk://#diff-54230d7f950949036ad92a8d71bdc5569f2165679973d38ea0600fa87b85ed4bR543-R565)`)