### PR TITLE
Set gantt inside a tab pane

### DIFF
--- a/public/layouts/task-card.php
+++ b/public/layouts/task-card.php
@@ -452,6 +452,7 @@ function render_comments( array $task_comments, int $parent_id, int $current_use
 		</div>
 
 		<!-- Gantt -->
+		<div class="tab-pane" id="gantt-tab">
 <?php
 /**
  * Generate Gantt chart data from _user_date_relations post meta.
@@ -551,11 +552,11 @@ foreach ( $user_dates as $user_id => $dates ) {
 
 // Output global JS variable for use by Chart.js.
 ?>
-<script type="text/javascript">
-	window.deckerGanttData = <?php echo wp_json_encode( $task_data ); ?>;
-</script>
-<canvas id="work-days-chart"></canvas>
-
+			<script type="text/javascript">
+				window.deckerGanttData = <?php echo wp_json_encode( $task_data ); ?>;
+			</script>
+			<canvas id="work-days-chart"></canvas>
+		</div>
 
 
 		<!-- Information -->


### PR DESCRIPTION
This pull request adds a new Gantt chart tab to the task card layout, allowing users to view Gantt chart data directly within the task interface. The changes focus on UI enhancements and better organization of chart-related content.

**UI and Layout Improvements:**

* Added a new `div` with the class `tab-pane` and ID `gantt-tab` to contain the Gantt chart section within the task card layout (`public/layouts/task-card.php`).
* Moved the closing `</div>` for the Gantt chart tab to properly encapsulate the chart content, ensuring the Gantt chart and its associated script are grouped together in the UI (`public/layouts/task-card.php`).