### PR TITLE
Fix creation of articles

### DIFF
--- a/public/layouts/kb-modal.php
+++ b/public/layouts/kb-modal.php
@@ -69,7 +69,7 @@
 	  </div>
 	  <div class="modal-footer">
 				<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?php esc_html_e( 'Close', 'decker' ); ?></button>
-				<button type="button" class="btn btn-success" id="guardar-articulo"><i class="ri-save-3-line me-1"></i> <?php esc_html_e( 'Save Article', 'decker' ); ?></button>
+				<button type="button" class="btn btn-success" id="save-article"><i class="ri-save-3-line me-1"></i> <?php esc_html_e( 'Save Article', 'decker' ); ?></button>
 	  </div>
 	</div>
   </div>
@@ -142,15 +142,18 @@ jQuery(function($){
 	destroyEditor();
   });
 
-  $('#guardar-articulo').on('click', function(){
+  $('#save-article').on('click', function(){
 	var form = $('#article-form')[0];
 	if (!form.checkValidity()) { form.classList.add('was-validated'); return; }
 
+	// Simplified: always prefer TinyMCE editor, fallback to textarea
 	var content = '';
 	try {
-	  if (window.wp && wp.editor && wp.editor.get('article-content')) content = wp.editor.get('article-content').getContent();
-	  if (!content && window.tinymce && tinymce.get('article-content')) content = tinymce.get('article-content').getContent();
-	  if (!content) content = ($('#article-content').val() || '');
+	  if (window.tinymce && tinymce.get('article-content')) {
+		content = tinymce.get('article-content').getContent();
+	  } else {
+		content = ($('#article-content').val() || '');
+	  }
 	} catch(e) { content = ($('#article-content').val() || ''); }
 
 	var $board = $('#article-board');


### PR DESCRIPTION
This pull request updates the article modal's save button and simplifies the logic for extracting article content when saving. The main improvements are a more consistent button identifier and a more straightforward approach to retrieving the editor content.

**UI Consistency:**

* Changed the save button's `id` from `guardar-articulo` to `save-article` in `kb-modal.php` for consistency and clarity.

**Content Extraction Logic:**

* Simplified the JavaScript logic to always prefer TinyMCE for retrieving article content, falling back to the textarea if TinyMCE is not available. This removes the previous preference for the WordPress editor and streamlines the save process.