### PR TITLE
fix(collab): prevent stale DB content from overwriting live text on enter/leave (Yjs race)

### DIFF
--- a/public/assets/js/decker-collaboration.js
+++ b/public/assets/js/decker-collaboration.js
@@ -415,6 +415,58 @@ import { QuillBinding } from 'https://esm.sh/y-quill@1.0.0?deps=yjs@13.6.20';
         // Use the provider's built-in awareness
         const awareness = provider.awareness;
 
+        // Track whether a real peer is (or was ever) present. Seeding the DB snapshot
+        // into the shared CRDT while a peer is live is what duplicates/overwrites the
+        // live content (Yjs merges, it never replaces), so this gates all seeding.
+        let peerEverSeen = false;
+
+        const countOtherAwareness = () => {
+            let count = 0;
+            awareness.getStates().forEach((state, clientId) => {
+                if (clientId !== awareness.clientID) {
+                    count++;
+                }
+            });
+            return count;
+        };
+
+        // y-webrtc 10.x keeps the live peer connections on provider.room; guard for
+        // version differences and for the unit-test mocks, which do not model a room.
+        const countWebrtcConns = () => {
+            const room = provider.room;
+            if (room && room.webrtcConns && typeof room.webrtcConns.size === 'number') {
+                return room.webrtcConns.size;
+            }
+            if (provider.webrtcConns && typeof provider.webrtcConns.size === 'number') {
+                return provider.webrtcConns.size;
+            }
+            return 0;
+        };
+
+        // True when we are NOT the authoritative seeder (another client exists).
+        const peersPresent = () => peerEverSeen || countOtherAwareness() > 0 || countWebrtcConns() > 0;
+
+        // y-webrtc emits 'peers' when a webrtc/broadcast peer connects. This fires
+        // before the Yjs document finishes syncing, so it is the earliest reliable
+        // signal that we are not alone.
+        const peersChangeHandler = (event) => {
+            const webrtc = (event && event.webrtcPeers && event.webrtcPeers.length) || 0;
+            const broadcast = (event && event.bcPeers && event.bcPeers.length) || 0;
+            const added = (event && event.added && event.added.length) || 0;
+            if (webrtc > 0 || broadcast > 0 || added > 0) {
+                peerEverSeen = true;
+            }
+        };
+        provider.on('peers', peersChangeHandler);
+
+        // Mark a peer as seen as soon as another awareness state appears.
+        const peerAwarenessHandler = () => {
+            if (countOtherAwareness() > 0) {
+                peerEverSeen = true;
+            }
+        };
+        awareness.on('change', peerAwarenessHandler);
+
         // Sync state tracking for event-based initialization
         let isSynced = false;
         let syncPromiseResolve = null;
@@ -433,35 +485,47 @@ import { QuillBinding } from 'https://esm.sh/y-quill@1.0.0?deps=yjs@13.6.20';
             }
         });
 
-        // Fast single-user detection: check periodically until we confirm status
+        // Single-user detection. The signaling socket opens almost immediately, but
+        // discovering and finishing the WebRTC handshake with an EXISTING peer (and
+        // syncing the Yjs doc) takes much longer. So we must NOT declare ourselves the
+        // sole/authoritative user just because the signaling socket is up and no peer
+        // has announced yet — we wait a quiet window long enough for a real peer to
+        // appear, and we bail out the moment any peer is detected (letting the real
+        // 'synced' event resolve instead).
         let singleUserCheckCount = 0;
-        const maxSingleUserChecks = 10; // Check up to 10 times (100ms * 10 = 1 second max)
+        const checkIntervalMs = 100;
+        // ~1.5s: comfortably exceeds typical WebRTC handshake + awareness propagation.
+        const singleUserMinChecks = 15;
+        // ~2s hard ceiling for the probe before proceeding regardless.
+        const maxSingleUserChecks = 20;
         let singleUserTimerId = null;
 
         const checkSingleUser = () => {
             if (isSynced) return; // Already synced, stop checking
 
             singleUserCheckCount++;
-            const signalingOk = isSignalingConnected(provider);
-            const peerCount = awareness.getStates().size;
 
-            // If signaling is connected and we're alone after a few checks, proceed
-            if (!isSynced && signalingOk && peerCount <= 1 && singleUserCheckCount >= 3) {
-                console.log('Decker Collaboration: Single user mode detected (check #' + singleUserCheckCount + ')');
+            // A peer connected (or its awareness arrived): stop probing for single-user
+            // and let the real Yjs 'synced' event resolve. Never seed over a peer.
+            if (peersPresent()) {
+                console.log('Decker Collaboration: Peer detected, waiting for real sync');
+                return;
+            }
+
+            const signalingOk = isSignalingConnected(provider);
+
+            // Only declare ourselves the authoritative user after a quiet window with
+            // the signaling socket up and no peer having appeared.
+            if (!isSynced && signalingOk && singleUserCheckCount >= singleUserMinChecks) {
+                console.log('Decker Collaboration: Single user mode confirmed (check #' + singleUserCheckCount + ')');
                 isSynced = true;
                 syncPromiseResolve();
                 return;
             }
 
-            // If we have peers, wait for proper sync
-            if (peerCount > 1) {
-                console.log('Decker Collaboration: Multiple peers detected, waiting for sync');
-                return; // Stop checking, let 'synced' event handle it
-            }
-
             // Keep checking until max attempts
             if (singleUserCheckCount < maxSingleUserChecks) {
-                singleUserTimerId = setTimeout(checkSingleUser, 100);
+                singleUserTimerId = setTimeout(checkSingleUser, checkIntervalMs);
             } else if (!isSynced) {
                 // All checks exhausted without resolution — resolve sync immediately
                 isSynced = true;
@@ -470,16 +534,16 @@ import { QuillBinding } from 'https://esm.sh/y-quill@1.0.0?deps=yjs@13.6.20';
         };
 
         // Start checking immediately
-        singleUserTimerId = setTimeout(checkSingleUser, 100);
+        singleUserTimerId = setTimeout(checkSingleUser, checkIntervalMs);
 
-        // Safety timeout: reduced to 2 seconds (only as last resort)
+        // Safety timeout (absolute last resort, beyond the single-user probe ceiling).
         const syncTimeout = setTimeout(() => {
             if (!isSynced) {
-                console.warn('Decker Collaboration: Sync timeout (2s), proceeding');
+                console.warn('Decker Collaboration: Sync timeout (3s), proceeding');
                 isSynced = true;
                 syncPromiseResolve();
             }
-        }, 2000);
+        }, 3000);
 
         // Clear timeout when sync completes normally
         syncPromise.then(() => clearTimeout(syncTimeout));
@@ -676,6 +740,15 @@ import { QuillBinding } from 'https://esm.sh/y-quill@1.0.0?deps=yjs@13.6.20';
              * @param {string} originalHtml - Original HTML content from server
              */
             initializeContentWithFallback(originalHtml) {
+                // Never seed the DB snapshot when a peer is (or was) present. Writing it
+                // into the shared CRDT would merge stale content with the peer's live
+                // edits (duplication/overwrite); when a peer exists we have already
+                // received their content through sync, so we keep it.
+                if (peersPresent()) {
+                    console.log('Decker Collaboration: Peer present, keeping synced content (no DB seed)');
+                    return;
+                }
+
                 // Only set content if Y.js document is empty
                 if (ytext.length === 0 && originalHtml && originalHtml.trim() !== '' && originalHtml !== '<p><br></p>') {
                     console.log('Decker Collaboration: Y.js empty after sync, initializing with original content:', originalHtml);
@@ -731,6 +804,15 @@ import { QuillBinding } from 'https://esm.sh/y-quill@1.0.0?deps=yjs@13.6.20';
             },
 
             /**
+             * Whether another collaborator is (or was ever) present in this session.
+             * Used by the form-fields layer to avoid seeding DB values over live ones.
+             * @returns {boolean}
+             */
+            hasPeers() {
+                return peersPresent();
+            },
+
+            /**
              * Get list of connected users
              */
             getConnectedUsers() {
@@ -777,12 +859,14 @@ import { QuillBinding } from 'https://esm.sh/y-quill@1.0.0?deps=yjs@13.6.20';
                 isDisabled = true;
 
                 awareness.off('change', awarenessStatusChangeHandler);
+                awareness.off('change', peerAwarenessHandler);
 
                 if (remoteCursorChangeHandler) {
                     awareness.off('change', remoteCursorChangeHandler);
                 }
 
                 provider.off('status', providerStatusChangeHandler);
+                provider.off('peers', peersChangeHandler);
 
                 // Remove selection change handler if it exists
                 if (selectionChangeHandler) {

--- a/public/assets/js/task-card.js
+++ b/public/assets/js/task-card.js
@@ -235,9 +235,25 @@
                 // Check if there are other peers connected (not just myself)
                 const connectedPeers = awareness.getStates().size;
                 const hasRemoteData = formFields.size > 0;
-                const isFirstUser = connectedPeers === 1 && !hasRemoteData;
+                // Trust the collaboration layer's peer-aware signal (real WebRTC
+                // connections + awareness), not just the awareness size sampled at this
+                // instant, which can transiently read 1 while a peer is mid-handshake.
+                const peerPresent = typeof session.hasPeers === 'function'
+                    ? session.hasPeers()
+                    : connectedPeers > 1;
 
-                console.log('Decker: Form sync - Connected peers:', connectedPeers, 'Has remote data:', hasRemoteData, 'Is first user:', isFirstUser);
+                // A peer is present but its form data has not synced yet: do NOT seed
+                // from the DB snapshot/DOM. Wait for observeRemoteChanges to apply the
+                // peer's live values when they arrive, otherwise we would overwrite them.
+                if (peerPresent && !hasRemoteData) {
+                    console.log('Decker: Peer present, awaiting remote form values (no DB seed)');
+                    isRemoteUpdate = false;
+                    return;
+                }
+
+                const isFirstUser = !peerPresent && connectedPeers === 1 && !hasRemoteData;
+
+                console.log('Decker: Form sync - Connected peers:', connectedPeers, 'Has remote data:', hasRemoteData, 'Peer present:', peerPresent, 'Is first user:', isFirstUser);
 
                 if (isFirstUser) {
                     if (!originalValuesSnapshot) {

--- a/tests/js/decker-collaboration.test.js
+++ b/tests/js/decker-collaboration.test.js
@@ -336,8 +336,9 @@ describe( 'DeckerCollaboration', () => {
 		const callback = jest.fn();
 		session.onSynced( callback );
 
-		// Run through all 10 checks (100ms each) + initial 100ms delay
-		for ( let i = 0; i <= 10; i++ ) {
+		// Run through all single-user checks (100ms each) + initial delay. The probe
+		// now waits a longer quiet window (~2s ceiling) before proceeding when alone.
+		for ( let i = 0; i <= 22; i++ ) {
 			jest.advanceTimersByTime( 100 );
 			await Promise.resolve(); // flush microtasks
 		}
@@ -379,5 +380,105 @@ describe( 'DeckerCollaboration', () => {
 		expect( mockYText.applyDelta ).toHaveBeenCalledWith( [
 			{ insert: 'hello' },
 		] );
+	} );
+} );
+
+// ── Race-condition regression guards (enter/leave content replacement) ──
+describe( 'DeckerCollaboration seeding race guards', () => {
+	/** Make the signaling socket appear OPEN. */
+	function connectSignaling() {
+		mockProvider.signalingConns = [ { ws: { readyState: 1 } } ];
+	}
+
+	/** Add a remote awareness peer (clientId !== self). */
+	function addAwarenessPeer( clientId = 2 ) {
+		mockProvider._awarenessStates.set( clientId, { user: { name: 'Peer' } } );
+	}
+
+	test( 'does NOT seed DB content when a peer is present in awareness', () => {
+		loadModule();
+		const session = initSession();
+
+		// A peer is already in the room (its awareness is visible).
+		addAwarenessPeer( 2 );
+
+		// Sync resolves and the editor tries to seed the stale DB snapshot.
+		mockProvider._fire( 'synced', { synced: true } );
+		session.initializeContentWithFallback( '<p>STALE DB CONTENT</p>' );
+
+		// The DB content must NOT be written into the shared CRDT: the peer's
+		// live content (delivered via sync) is kept instead.
+		expect( mockQuill.clipboard.convert ).not.toHaveBeenCalled();
+		expect( mockYText.applyDelta ).not.toHaveBeenCalled();
+		expect( mockYText.insert ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does NOT seed DB content once a peers event has fired (peerEverSeen latch)', () => {
+		loadModule();
+		const session = initSession();
+
+		// y-webrtc reports a connected peer before the Yjs doc finishes syncing.
+		mockProvider._fire( 'peers', { added: [ 2 ], webrtcPeers: [ 2 ], bcPeers: [] } );
+
+		mockProvider._fire( 'synced', { synced: true } );
+		session.initializeContentWithFallback( '<p>STALE DB CONTENT</p>' );
+
+		expect( mockQuill.clipboard.convert ).not.toHaveBeenCalled();
+		expect( mockYText.applyDelta ).not.toHaveBeenCalled();
+	} );
+
+	test( 'still seeds DB content when genuinely alone (no peers)', () => {
+		loadModule();
+		const session = initSession();
+
+		mockProvider._fire( 'synced', { synced: true } );
+		session.initializeContentWithFallback( '<p>Hello world</p>' );
+
+		// No peer present -> we are the authoritative seeder, content is applied.
+		expect( mockQuill.clipboard.convert ).toHaveBeenCalledWith( {
+			html: '<p>Hello world</p>',
+		} );
+		expect( mockYText.applyDelta ).toHaveBeenCalled();
+	} );
+
+	test( 'does NOT declare single-user prematurely (~300ms); waits the settle window', async () => {
+		loadModule();
+		connectSignaling();
+
+		const session = initSession();
+
+		// Advance ~300ms (the old premature threshold) — must NOT be synced yet.
+		for ( let i = 0; i < 4; i++ ) {
+			jest.advanceTimersByTime( 100 );
+			await Promise.resolve();
+		}
+		expect( session.isSynced() ).toBe( false );
+
+		// Advance through the full quiet window — now a genuinely-alone user resolves.
+		for ( let i = 0; i < 14; i++ ) {
+			jest.advanceTimersByTime( 100 );
+			await Promise.resolve();
+		}
+		expect( session.isSynced() ).toBe( true );
+	} );
+
+	test( 'does NOT declare single-user while a peer is present; waits for real sync', async () => {
+		loadModule();
+		connectSignaling();
+		addAwarenessPeer( 2 ); // peer present from the start
+
+		const session = initSession();
+
+		// Even well past the single-user window, presence of a peer prevents the
+		// premature single-user resolution (sync must come from the peer).
+		for ( let i = 0; i < 20; i++ ) {
+			jest.advanceTimersByTime( 100 );
+			await Promise.resolve();
+		}
+		expect( session.isSynced() ).toBe( false );
+
+		// The real Yjs sync event resolves it.
+		mockProvider._fire( 'synced', { synced: true } );
+		expect( session.isSynced() ).toBe( true );
 	} );
 } );

--- a/tests/js/task-card-collaboration-cleanup.test.js
+++ b/tests/js/task-card-collaboration-cleanup.test.js
@@ -289,4 +289,52 @@ describe( 'Task card collaboration cleanup', () => {
 
 		jest.useRealTimers();
 	} );
+
+	test( 'does NOT seed form fields from the snapshot when a peer is present', () => {
+		const context = setupDOM();
+		const formFields = createMockFormFields(); // empty: peer data not synced yet
+		const awareness = createMockAwareness(); // self + teammate
+		const session = {
+			formFields,
+			awareness,
+			hasPeers: () => true,
+			onSynced: jest.fn( ( callback ) => callback() ),
+			setActiveField: jest.fn(),
+			clearActiveField: jest.fn(),
+		};
+
+		initFormFieldsCollaboration( session, context );
+
+		// The joining user must wait for the peer's live values instead of
+		// overwriting the shared map with the stale DB snapshot.
+		expect( formFields.set ).not.toHaveBeenCalled();
+	} );
+
+	test( 'seeds form fields from the snapshot when genuinely alone (first user)', () => {
+		const context = setupDOM();
+		const formFields = createMockFormFields(); // empty
+		const awareness = {
+			clientID: 1,
+			getStates: jest.fn(
+				() => new Map( [ [ 1, { user: { name: 'Me' } } ] ] )
+			),
+			on: jest.fn(),
+			off: jest.fn(),
+			setLocalStateField: jest.fn(),
+		};
+		const session = {
+			formFields,
+			awareness,
+			hasPeers: () => false,
+			onSynced: jest.fn( ( callback ) => callback() ),
+			setActiveField: jest.fn(),
+			clearActiveField: jest.fn(),
+		};
+
+		initFormFieldsCollaboration( session, context );
+
+		// First user populates the shared map from the original snapshot values.
+		expect( formFields.set ).toHaveBeenCalledWith( 'title', 'Original title' );
+		expect( formFields.set ).toHaveBeenCalledWith( 'board', 'board1' );
+	} );
 } );


### PR DESCRIPTION
## Problem

In collaborative editing (Yjs + y-webrtc, peer-to-peer), the live document could be **replaced or duplicated by the stale database content** when a user entered — or re-entered — a task that another user was already editing. The same symptom appeared "on leave" (it's the same race on re-entry while a peer is still editing).

## Root cause

When a session initializes, the signaling socket opens almost immediately, but discovering + finishing the **WebRTC handshake** with an existing peer and syncing the Yjs document takes much longer (500 ms–2 s+). The old code declared itself the **sole/authoritative user** just ~300 ms after init, using only `signaling socket open + awareness peerCount <= 1`:

```js
if (signalingOk && peerCount <= 1 && singleUserCheckCount >= 3) { /* "I'm alone" */ }
```

A late joiner therefore believed it was alone before the peer announced itself, and **seeded the DB snapshot into the shared CRDT** — both the editor text (`ytext`) and the form-fields `Y.Map`. Because Yjs *merges* (it never replaces), that stale seed was then concatenated / resolved last-write-wins against the peer's live content, so live edits got **clobbered or duplicated**. The form-fields `isFirstUser = connectedPeers === 1 && !hasRemoteData` check had the identical race.

A deep analysis confirmed there is **no distinct destroy/disconnect-time writeback** — the "leave" symptom is the same seeding race firing on re-entry.

## Fix

- **Detect peers for real, not on a timer.** "Am I alone?" now relies on the y-webrtc `peers` event, actual WebRTC connections, and awareness — plus a proper settle window — instead of a 300 ms heuristic. The moment a peer is detected, the single-user probe stops and the real Yjs `synced` event resolves the sync.
- **Never seed over a peer (belt-and-suspenders).** DB seeding is hard-guarded by "no peer present" in **both** the editor (`initializeContentWithFallback`) and the form-fields first-user path. When a peer is present but its data hasn't synced yet, the joiner now **waits for the remote values** instead of overwriting them. The session exposes `hasPeers()`.
- A genuinely-alone user still seeds from the DB exactly as before.

## Tests

7 new jest cases (full JS suite green — 30 tests):
- no DB seed when a peer is present in awareness;
- no DB seed once a `peers` event has fired (peer-seen latch);
- still seeds when genuinely alone;
- does **not** declare single-user prematurely (~300 ms); resolves after the settle window;
- does **not** declare single-user while a peer is present (waits for real sync);
- form-fields seed-guard verified against the **real** extracted code (peer present → no seed; alone → seeds).

## Trade-off

A genuinely-alone user now waits the settle window (~1.5 s) before the DB content paints, instead of ~300 ms. Multi-user sessions are **not** delayed — they resolve as soon as the real `synced` event fires. This is the correct trade-off vs. clobbering live collaborative content.