### PR TITLE
ci: add WordPress Playground PR preview (official action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  deployments: write
 
 jobs:
   lint_and_test:
@@ -21,66 +19,8 @@ jobs:
       # Checkout the code
       - uses: actions/checkout@v6
 
-      # Determine the branch name
-      - name: Set branch name for blueprint URL
-        shell: bash
-        run: |
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            echo "BRANCH_NAME=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-          else
-            echo "BRANCH_NAME=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-          fi
-
-      # Replace main.zip with <BRANCH_NAME>.zip in blueprint.json
-      - name: Patch blueprint.json with branch ZIP
-        run: |
-          sed -i "s|refs/heads/main.zip|refs/heads/${BRANCH_NAME}.zip|g" blueprint.json
-
-      # Convert blueprint.json to Base64, because github not processes well json in urls
-      - name: Encode blueprint for Playground
-        id: blueprint
-        run: |
-          # Base64-encode the blueprint (no line wraps)
-          BASE64_BLUEPRINT=$(base64 -w 0 blueprint.json)
-          echo "BASE64_BLUEPRINT=$BASE64_BLUEPRINT" >> $GITHUB_ENV
-
-      # Show final Playground URL in the Summary
-      - name: Add Playground URL to summary
-        run: |
-          echo "[Test in WP Playground](https://playground.wordpress.net/#${BASE64_BLUEPRINT})" >> $GITHUB_STEP_SUMMARY
-
-      # Create a deployment with the Playground URL
-      - name: Create a deployment
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const encodedBlueprint = process.env.BASE64_BLUEPRINT;
-            const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
-
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request ? context.payload.pull_request.head.ref : context.ref,
-              required_contexts: [],
-              environment: "playground",
-              transient_environment: true,
-              auto_merge: false,
-              description: "WordPress Playground Deployment"
-            });
-
-            if (deployment.data.id) {
-              await github.rest.repos.createDeploymentStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                deployment_id: deployment.data.id,
-                state: "success",
-                environment_url: playgroundUrl,
-                description: "Playground environment ready"
-              });
-            }
-
-
+      # Note: the WordPress Playground PR preview link is posted by the dedicated
+      # playground-preview.yml workflow (WordPress/action-wp-playground-pr-preview).
 
       - name: Pre-pull Docker images
         run: |

--- a/.github/workflows/playground-preview.yml
+++ b/.github/workflows/playground-preview.yml
@@ -1,0 +1,52 @@
+name: Playground PR Preview
+
+# Posts a WordPress Playground preview link on every pull request, booting a
+# clean WordPress in the browser (WebAssembly) with this PR's build of the
+# Decker plugin installed and activated. Uses the official
+# WordPress/action-wp-playground-pr-preview action.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: WordPress Playground preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Playground preview link
+        uses: WordPress/action-wp-playground-pr-preview@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          mode: comment
+          # Custom blueprint: install THIS PR's plugin from its branch ZIP and
+          # reproduce the demo environment (Spanish, two editor users, land on the
+          # Decker priority board). When `blueprint` is set, `plugin-path` is ignored.
+          blueprint: |
+            {
+              "$schema": "https://playground.wordpress.net/blueprint-schema.json",
+              "preferredVersions": { "php": "latest", "wp": "latest" },
+              "siteOptions": { "blogname": "WordPress Playground Decker Demo" },
+              "features": { "networking": true },
+              "login": true,
+              "landingPage": "/?decker_page=priority",
+              "steps": [
+                { "step": "setSiteLanguage", "language": "es_ES" },
+                {
+                  "step": "runPHP",
+                  "code": "<?php require_once('/wordpress/wp-load.php'); wp_insert_user(array('user_login' => 'test_user_1', 'user_email' => 'test1@example.com', 'user_pass' => wp_generate_password(), 'role' => 'editor')); wp_insert_user(array('user_login' => 'test_user_2', 'user_email' => 'test2@example.com', 'user_pass' => wp_generate_password(), 'role' => 'editor')); ?>"
+                },
+                {
+                  "step": "installPlugin",
+                  "pluginData": {
+                    "resource": "url",
+                    "url": "https://github.com/${{ github.event.pull_request.head.repo.full_name }}/archive/refs/heads/${{ github.event.pull_request.head.ref }}.zip"
+                  },
+                  "options": { "activate": true }
+                }
+              ]
+            }


### PR DESCRIPTION
## What

Implements [WordPress/action-wp-playground-pr-preview](https://github.com/WordPress/action-wp-playground-pr-preview) so every PR gets a one-click **WordPress Playground** preview — a clean WordPress booted in the browser (WebAssembly) with this PR's build of the Decker plugin installed and activated.

## How

- New workflow `.github/workflows/playground-preview.yml` using the action at `@v3`, `mode: comment`, with a custom **blueprint** that:
  - installs the plugin from **this PR's branch ZIP** (`…/archive/refs/heads/<head-ref>.zip`, resolved from the PR's head repo so forks work too),
  - reproduces the demo environment: Spanish (`es_ES`), two editor users (`test_user_1`, `test_user_2`), networking enabled, and lands on the Decker priority board (`/?decker_page=priority`).
- Removes the homegrown Playground steps from `ci.yml` (manual `blueprint.json` patch → base64 URL → GitHub deployment) that the action now supersedes, and drops the `pull-requests`/`deployments: write` permissions those steps required from the CI job (it now only needs `contents: read`).
- `blueprint.json` (the standalone "try main" link) is left unchanged.

## Notes

- The plugin runs directly from source in Playground (no Composer/npm build needed — `decker.php` doesn't hard-require `vendor/`), so the simple no-build setup is used.
- For same-repo branch PRs the preview comment posts normally. For fork PRs, `pull_request`'s `GITHUB_TOKEN` is read-only by design, so the comment is skipped — consistent with the previous setup; the fork-safe two-workflow pattern can be adopted later if external contributions need previews.