### PR TITLE
fix(comments): make task comment URLs clickable after reload (#260)

### DIFF
--- a/public/layouts/partials/task-comments.php
+++ b/public/layouts/partials/task-comments.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Task comment rendering helper.
+ *
+ * Extracted from task-card.php so the rendering logic can be reused by the
+ * template and covered by unit tests.
+ *
+ * @package    Decker
+ * @subpackage Decker/public
+ * @author     ATE <ate.educacion@gobiernodecanarias.org>
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'render_comments' ) ) {
+	/**
+	 * Organizes and renders comments in a hierarchical structure.
+	 *
+	 * This function processes an array of comments, organizing them
+	 * into a nested structure based on their parent ID. It also allows
+	 * for specific handling of comments based on the current user's ID.
+	 *
+	 * @param array $task_comments        An array of comment objects or arrays,
+	 *                               each containing information about a comment.
+	 * @param int   $parent_id       The ID of the parent comment. Use 0 for top-level comments.
+	 * @param int   $current_user_id The ID of the currently logged-in user.
+	 *                               Used to customize rendering for the user.
+	 *
+	 * @return void
+	 */
+	function render_comments( array $task_comments, int $parent_id, int $current_user_id ) {
+		foreach ( $task_comments as $comment ) {
+			if ( $comment->comment_parent == $parent_id ) {
+					   // Get replies recursively.
+				echo '<div class="d-flex align-items-start mb-2" style="margin-left:' . ( $comment->comment_parent ? '20px' : '0' ) . ';">';
+				echo '<img class="me-2 rounded-circle" src="' . esc_url( get_avatar_url( $comment->user_id, array( 'size' => 48 ) ) ) . '" alt="Avatar" height="32" />';
+				echo '<div class="w-100">';
+				echo '<h5 class="mt-0">' . esc_html( $comment->comment_author ) . ' <small class="text-muted float-end">' . esc_html( get_comment_date( '', $comment ) ) . '</small></h5>';
+				// Use the 'comment_text' filter (not 'the_content') so URLs become
+				// clickable links, matching the REST API output used by the AJAX path.
+				echo wp_kses_post( apply_filters( 'comment_text', $comment->comment_content, $comment ) );
+
+					   // Show delete link if the comment belongs to the current user.
+				if ( get_current_user_id() == $comment->user_id ) {
+					echo '<a href="javascript:void(0);" onclick="deleteComment(' . esc_attr( $comment->comment_ID ) . ');" class="text-muted d-inline-block mt-2 comment-delete" data-comment-id="' . esc_attr( $comment->comment_ID ) . '"><i class="ri-delete-bin-line"></i> ' . esc_html__( 'Delete', 'decker' ) . '</a> ';
+
+				}
+
+				/* echo '<a href="javascript:void(0);" class="text-muted d-inline-block mt-2 comment-reply" data-comment-id="' . esc_attr( $comment->comment_ID ) . '"><i class="ri-reply-line"></i> Reply</a>'; */
+
+				echo '</div>';
+				echo '</div>';
+
+					   // Recursive call to render replies.
+				render_comments( $task_comments, $comment->comment_ID, $current_user_id );
+			}
+		}
+	}
+}

--- a/public/layouts/task-card.php
+++ b/public/layouts/task-card.php
@@ -107,47 +107,8 @@ if ( $task_id ) {
 
 }
 
-/**
- * Organizes and renders comments in a hierarchical structure.
- *
- * This function processes an array of comments, organizing them
- * into a nested structure based on their parent ID. It also allows
- * for specific handling of comments based on the current user's ID.
- *
- * @param array $task_comments        An array of comment objects or arrays,
- *                               each containing information about a comment.
- * @param int   $parent_id       The ID of the parent comment. Use 0 for top-level comments.
- * @param int   $current_user_id The ID of the currently logged-in user.
- *                               Used to customize rendering for the user.
- *
- * @return void
- */
-function render_comments( array $task_comments, int $parent_id, int $current_user_id ) {
-	foreach ( $task_comments as $comment ) {
-		if ( $comment->comment_parent == $parent_id ) {
-				   // Get replies recursively.
-			echo '<div class="d-flex align-items-start mb-2" style="margin-left:' . ( $comment->comment_parent ? '20px' : '0' ) . ';">';
-			echo '<img class="me-2 rounded-circle" src="' . esc_url( get_avatar_url( $comment->user_id, array( 'size' => 48 ) ) ) . '" alt="Avatar" height="32" />';
-			echo '<div class="w-100">';
-			echo '<h5 class="mt-0">' . esc_html( $comment->comment_author ) . ' <small class="text-muted float-end">' . esc_html( get_comment_date( '', $comment ) ) . '</small></h5>';
-			echo wp_kses_post( apply_filters( 'the_content', $comment->comment_content ) );
-
-				   // Show delete link if the comment belongs to the current user.
-			if ( get_current_user_id() == $comment->user_id ) {
-				echo '<a href="javascript:void(0);" onclick="deleteComment(' . esc_attr( $comment->comment_ID ) . ');" class="text-muted d-inline-block mt-2 comment-delete" data-comment-id="' . esc_attr( $comment->comment_ID ) . '"><i class="ri-delete-bin-line"></i> ' . esc_html__( 'Delete', 'decker' ) . '</a> ';
-
-			}
-
-			/* echo '<a href="javascript:void(0);" class="text-muted d-inline-block mt-2 comment-reply" data-comment-id="' . esc_attr( $comment->comment_ID ) . '"><i class="ri-reply-line"></i> Reply</a>'; */
-
-			echo '</div>';
-			echo '</div>';
-
-				   // Recursive call to render replies.
-			render_comments( $task_comments, $comment->comment_ID, $current_user_id );
-		}
-	}
-}
+// Load the comment rendering helper (render_comments()).
+require_once __DIR__ . '/partials/task-comments.php';
 ?>
 
 <!-- Task card -->

--- a/tests/unit/includes/custom-post-types/DeckerTaskCommentsTest.php
+++ b/tests/unit/includes/custom-post-types/DeckerTaskCommentsTest.php
@@ -97,6 +97,42 @@ class DeckerTaskCommentsTest extends Decker_Test_Base {
 	}
 
 	/**
+	 * A comment containing a URL must be rendered with a clickable link.
+	 *
+	 * render_comments() (used when the task is reloaded) must render URLs as
+	 * clickable links, matching the REST API output used by the AJAX path.
+	 * This guards against regressing back to the 'the_content' filter, which
+	 * does not apply make_clickable() and leaves URLs as plain text. See #260.
+	 */
+	public function test_comment_url_is_rendered_as_clickable_link() {
+		require_once dirname( __DIR__, 4 ) . '/public/layouts/partials/task-comments.php';
+
+		wp_set_current_user( $this->administrator );
+
+		$url        = 'https://example.com/path';
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => $this->task_id,
+				'comment_content' => "Check this out $url please",
+				'user_id'         => $this->administrator,
+			)
+		);
+
+		$comment = get_comment( $comment_id );
+
+		ob_start();
+		render_comments( array( $comment ), 0, $this->administrator );
+		$rendered = ob_get_clean();
+
+		$this->assertStringContainsString(
+			'href="' . $url . '"',
+			$rendered,
+			'Comment URL should be rendered as a clickable link on task reload.'
+		);
+		$this->assertStringContainsString( '<a ', $rendered, 'Rendered comment should contain an anchor tag.' );
+	}
+
+	/**
 	 * Clean up after each test.
 	 */
 	public function tear_down() {


### PR DESCRIPTION
Closes #260.

### Problem

When a task comment contains a URL, the link **is** clickable when the comment is added live via AJAX, but after the task is reloaded the URL is rendered as plain text.

### Cause

- **AJAX add** renders `content.rendered` from the WordPress REST API, which applies the `comment_text` filter. WP core hooks `make_clickable()` onto `comment_text`, so URLs become links.
- **Page load** rendered comments in `task-card.php` using `apply_filters( 'the_content', ... )`, which has no `make_clickable()`, so URLs stayed as plain text.

### Fix

- Render existing comments with the `comment_text` filter (matching the REST/AJAX path) so links are clickable consistently.
- Extract `render_comments()` into a reusable partial (`public/layouts/partials/task-comments.php`) so the rendering logic can be unit tested.

### Tests

- Added `DeckerTaskCommentsTest::test_comment_url_is_rendered_as_clickable_link`, which renders a comment containing a URL via `render_comments()` and asserts the output contains an `<a href="...">` link. Verified it **fails** with the old `the_content` filter and **passes** with `comment_text`.

```
Decker Task Comments
 ✔ Comments by roles
 ✔ Comment url is rendered as clickable link
OK (2 tests, 17 assertions)
```