### PR TITLE
ci(release): fix empty tag when publishing release from a draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,12 @@ jobs:
 
       - name: Set environment variables
         run: |
-          RAW_TAG="${GITHUB_REF##*/}"
+          RAW_TAG="${{ github.event.release.tag_name }}"
           VERSION_TAG="${RAW_TAG#v}"  # Delete the initial 'v' if exists
+          if [ -z "$VERSION_TAG" ]; then
+            echo "::error::Could not determine release tag" >&2
+            exit 1
+          fi
           echo "RELEASE_TAG=${VERSION_TAG}" >> $GITHUB_ENV
 
       - name: Create package using the Makefile


### PR DESCRIPTION
## Problem

The `v2.1.10` release job failed:

```
Error: No se ha especificado una versión. Usa 'make package VERSION=1.2.3'
make: *** [Makefile:200: package] Error 1
```

Root cause: the job derived the version from `$GITHUB_REF`. When a release is **published from a draft**, `GITHUB_REF` can arrive empty, leaving `RELEASE_TAG` empty and breaking `make package VERSION=`. As a result no ZIP asset was uploaded to v2.1.10. The same workflow worked for v2.1.9 (published directly), which is why it looked like a regression.

## Fix

- Read the tag from `github.event.release.tag_name`, which is always present in the `release` event payload regardless of draft/publish flow.
- Fail fast with a clear error if the tag is somehow empty, instead of bubbling up as a confusing `make` error.

No code/version changes — versioning still lives in the git tag.