### PR TITLE
feat(email): route email-created tasks to boards via subject directive

### DIFF
--- a/includes/class-decker-email-to-post.php
+++ b/includes/class-decker-email-to-post.php
@@ -443,10 +443,10 @@ class Decker_Email_To_Post {
 	 * @return int|WP_Error The task ID if successful, or a WP_Error on failure.
 	 */
 	private function create_task( $email_data, $author, $assigned_users ) {
-		// Get default board.
-		$default_board = (int) get_user_meta( $author->ID, 'decker_default_board', true );
-		if ( $default_board <= 0 || ! term_exists( $default_board, 'decker_board' ) ) {
-			return new WP_Error( 'invalid_board', 'Invalid default board' );
+		// Resolve the target board and the cleaned subject, supporting subject board directives.
+		$resolved = $this->resolve_board_and_subject_from_email( $email_data['subject'], $author->ID );
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
 		// Set task parameters.
@@ -455,10 +455,10 @@ class Decker_Email_To_Post {
 		// Create task.
 		$task_id = Decker_Tasks::create_or_update_task(
 			0,
-			$email_data['subject'],
+			$resolved['subject'],
 			$email_data['body'],
 			'to-do',
-			$default_board,
+			$resolved['board_id'],
 			false,
 			$due_date,
 			$author->ID,
@@ -469,6 +469,154 @@ class Decker_Email_To_Post {
 		);
 
 		return $task_id;
+	}
+
+	/**
+	 * Resolves the target board and the cleaned subject for a task created from email.
+	 *
+	 * Supports an optional board directive at the start of the subject:
+	 *   [slug] Title         -> board with slug "slug" (shorthand).
+	 *   [board:slug] Title   -> same, explicit qualifier.
+	 *   [tablero:slug] Title -> same, Spanish qualifier.
+	 *
+	 * When the directive matches an existing board, that board is used and the directive is
+	 * stripped from the title. When no directive is present, the sender's default board is
+	 * used. An explicit "board:"/"tablero:" qualifier that references a missing board fails
+	 * with 'invalid_board_slug'; a bare "[slug]" that matches no board is treated as a literal
+	 * title and falls back to the default board, so legitimate bracketed subject prefixes
+	 * (e.g. "[URGENT] ...") are never dropped.
+	 *
+	 * @param string $subject   The raw email subject.
+	 * @param int    $author_id The sender WordPress user ID.
+	 * @return array|WP_Error An array with 'board_id', 'subject' and 'source' on success,
+	 *                        or a WP_Error on failure.
+	 */
+	private function resolve_board_and_subject_from_email( string $subject, int $author_id ) {
+		$directive = $this->parse_board_directive_from_subject( $subject );
+
+		$board_id = null;
+		$title    = $directive['original'];
+		$source   = 'default';
+
+		if ( null !== $directive['slug'] ) {
+			$board_id = $this->get_board_by_slug( $directive['slug'] );
+
+			if ( null !== $board_id ) {
+				// Directive matched a board: route there and strip it from the title.
+				$title  = $directive['title'];
+				$source = 'subject';
+			} elseif ( $directive['qualified'] ) {
+				// Explicit "board:"/"tablero:" directive with no matching board: fail loudly.
+				return new WP_Error(
+					'invalid_board_slug',
+					'The board referenced in the subject does not exist',
+					array( 'status' => 400 )
+				);
+			}
+			// Bare "[slug]" with no matching board: keep $board_id null so the default
+			// board is used below, preserving the original subject as the title.
+		}
+
+		if ( null === $board_id ) {
+			$board_id = $this->get_default_board_for_user( $author_id );
+			if ( is_wp_error( $board_id ) ) {
+				return $board_id;
+			}
+		}
+
+		if ( '' === $title ) {
+			return new WP_Error(
+				'missing_field',
+				'The title is required',
+				array( 'status' => 400 )
+			);
+		}
+
+		return array(
+			'board_id' => $board_id,
+			'subject'  => $title,
+			'source'   => $source,
+		);
+	}
+
+	/**
+	 * Parses an optional board directive from the start of an email subject.
+	 *
+	 * Recognizes "[slug]", "[board:slug]" and "[tablero:slug]" at the beginning of the
+	 * subject. The slug is normalized with sanitize_title() so matching is case-insensitive.
+	 *
+	 * @param string $subject The raw email subject.
+	 * @return array {
+	 *     @type string|null $slug      The normalized board slug, or null when no usable directive is present.
+	 *     @type bool        $qualified Whether an explicit "board:"/"tablero:" qualifier was used.
+	 *     @type string      $title     The title with the directive stripped (used when the board matches).
+	 *     @type string      $original  The trimmed subject with the directive preserved (fallback title).
+	 * }
+	 */
+	private function parse_board_directive_from_subject( string $subject ): array {
+		$trimmed = trim( $subject );
+
+		$result = array(
+			'slug'      => null,
+			'qualified' => false,
+			'title'     => $trimmed,
+			'original'  => $trimmed,
+		);
+
+		// Match a leading "[ ... ]" directive followed by the remaining title.
+		if ( ! preg_match( '/^\[\s*([^\]]+?)\s*\]\s*(.*)$/s', $trimmed, $matches ) ) {
+			return $result;
+		}
+
+		$directive = $matches[1];
+		$remainder = trim( $matches[2] );
+
+		// Strip an optional "board:" or "tablero:" qualifier.
+		$qualified = false;
+		if ( preg_match( '/^(?:board|tablero)\s*:\s*(.+)$/i', $directive, $qualifier ) ) {
+			$directive = $qualifier[1];
+			$qualified = true;
+		}
+
+		$slug = sanitize_title( $directive );
+		if ( '' === $slug ) {
+			// Not a usable directive (e.g. "[ ]" or "[!!!]"); treat the subject as having none.
+			return $result;
+		}
+
+		$result['slug']      = $slug;
+		$result['qualified'] = $qualified;
+		$result['title']     = $remainder;
+
+		return $result;
+	}
+
+	/**
+	 * Returns the sender's default board, preserving the historical error contract.
+	 *
+	 * @param int $user_id The sender WordPress user ID.
+	 * @return int|WP_Error The board term ID, or a WP_Error when it is missing or invalid.
+	 */
+	private function get_default_board_for_user( int $user_id ) {
+		$default_board = (int) get_user_meta( $user_id, 'decker_default_board', true );
+		if ( $default_board <= 0 || ! term_exists( $default_board, 'decker_board' ) ) {
+			return new WP_Error( 'invalid_board', 'Invalid default board' );
+		}
+		return $default_board;
+	}
+
+	/**
+	 * Returns the term ID of a decker_board by slug.
+	 *
+	 * @param string $slug The board slug.
+	 * @return int|null The board term ID, or null when no board matches.
+	 */
+	private function get_board_by_slug( string $slug ) {
+		$term = get_term_by( 'slug', $slug, 'decker_board' );
+		if ( ! $term instanceof WP_Term ) {
+			return null;
+		}
+		return (int) $term->term_id;
 	}
 
 	/**

--- a/tests/unit/includes/DeckerEmailToPostTest.php
+++ b/tests/unit/includes/DeckerEmailToPostTest.php
@@ -512,6 +512,342 @@ class DeckerEmailToPostTest extends Decker_Test_Base {
 	}
 
 	/**
+	 * A bracket directive routes the task to the matching board and strips the directive.
+	 */
+	public function test_creates_task_on_board_from_bracket_subject_slug() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '[soe] pepito pérez' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'task_id', $data );
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( 'pepito pérez', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $soe_board_id, $boards );
+		$this->assertNotContains( $this->board_id, $boards );
+	}
+
+	/**
+	 * The explicit "board:" directive routes the task to the matching board.
+	 */
+	public function test_creates_task_on_board_from_explicit_board_subject_directive() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '[board:soe] pepito pérez' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( 'pepito pérez', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $soe_board_id, $boards );
+		$this->assertNotContains( $this->board_id, $boards );
+	}
+
+	/**
+	 * The Spanish "tablero:" directive routes the task to the matching board.
+	 */
+	public function test_creates_task_on_board_from_spanish_subject_directive() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '[tablero:soe] pepito pérez' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( 'pepito pérez', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $soe_board_id, $boards );
+		$this->assertNotContains( $this->board_id, $boards );
+	}
+
+	/**
+	 * The board directive is matched case-insensitively from the user's perspective.
+	 */
+	public function test_board_subject_directive_is_case_insensitive() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '[SOE] pepito pérez' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( 'pepito pérez', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $soe_board_id, $boards );
+	}
+
+	/**
+	 * Without a directive, the task keeps using the sender's default board.
+	 */
+	public function test_email_without_board_directive_uses_default_board() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( 'Plain task without directive' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( 'Plain task without directive', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $this->board_id, $boards );
+	}
+
+	/**
+	 * An explicit "board:"/"tablero:" directive for an unknown board fails instead of falling back.
+	 */
+	public function test_invalid_bracket_board_directive_returns_error() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+
+		$response = $this->dispatch_email_with_subject( '[board:unknown-board] pepito pérez' );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'invalid_board_slug', $data['code'] );
+
+		$this->assertEquals( 0, $this->count_decker_tasks(), 'No task should be created for an unknown explicit board slug' );
+	}
+
+	/**
+	 * A bare "[xxx]" that matches no board falls back to the default board with the title intact.
+	 *
+	 * This protects common bracketed subject prefixes (e.g. "[URGENT] ...") from being dropped.
+	 */
+	public function test_unmatched_bare_bracket_falls_back_to_default_board() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '[URGENT] Fix the login bug' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'task_id', $data );
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( '[URGENT] Fix the login bug', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $this->board_id, $boards );
+		$this->assertNotContains( $soe_board_id, $boards );
+	}
+
+	/**
+	 * The directive is matched by board slug, never by the board's display name.
+	 */
+	public function test_board_directive_matches_by_slug_not_name() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		// Name sanitizes to "sales-operations" but the slug is "soe".
+		$board_id = $this->create_board_with_slug( 'soe', 'Sales Operations' );
+
+		// The slug matches and routes to the board.
+		$response = $this->dispatch_email_with_subject( '[soe] pepito pérez' );
+		$this->assertEquals( 200, $response->get_status() );
+		$boards = $this->get_task_board_ids( $response->get_data()['task_id'] );
+		$this->assertContains( $board_id, $boards );
+
+		// The sanitized name is NOT a slug, so an explicit directive for it must fail.
+		$response = $this->dispatch_email_with_subject( '[board:sales-operations] pepito pérez' );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'invalid_board_slug', $response->get_data()['code'] );
+	}
+
+	/**
+	 * A leading bracket whose content sanitizes to an empty slug is treated as a literal title.
+	 */
+	public function test_bracket_with_empty_slug_falls_back_to_default_board() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '[!!!] real title' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( '[!!!] real title', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $this->board_id, $boards );
+		$this->assertNotContains( $soe_board_id, $boards );
+	}
+
+	/**
+	 * Whitespace around and inside the directive is tolerated when routing and cleaning the title.
+	 */
+	public function test_board_directive_tolerates_surrounding_whitespace() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '  [ soe ]   pepito pérez  ' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( 'pepito pérez', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $soe_board_id, $boards );
+		$this->assertNotContains( $this->board_id, $boards );
+	}
+
+	/**
+	 * A directive that leaves no title behind is rejected without creating a task.
+	 */
+	public function test_empty_title_after_board_directive_is_rejected() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$this->create_board_with_slug( 'soe', 'SOE' );
+
+		$response = $this->dispatch_email_with_subject( '[soe]' );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'missing_field', $data['code'] );
+
+		$this->assertEquals( 0, $this->count_decker_tasks(), 'No empty-title task should be created' );
+	}
+
+	/**
+	 * Board routing must not change attachment handling.
+	 */
+	public function test_board_directive_does_not_break_attachments() {
+		update_user_meta( $this->user_id, 'decker_default_board', $this->board_id );
+		$soe_board_id = $this->create_board_with_slug( 'soe', 'SOE' );
+
+		$pdf_content = $this->get_fixture_content( 'sample-1.pdf' );
+		$raw_email   = $this->build_email_with_attachment(
+			'sample-1.pdf',
+			'application/pdf',
+			$pdf_content
+		);
+
+		$response = $this->dispatch_raw_email_with_subject( $raw_email, '[soe] Task with Attachment' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'task_id', $data );
+
+		$task = get_post( $data['task_id'] );
+		$this->assertEquals( 'Task with Attachment', $task->post_title );
+
+		$boards = $this->get_task_board_ids( $data['task_id'] );
+		$this->assertContains( $soe_board_id, $boards );
+
+		$attachments = get_attached_media( '', $data['task_id'] );
+		$this->assertCount( 1, $attachments, 'Legitimate PDF attachment must still be uploaded' );
+	}
+
+	/**
+	 * Creates a decker_board term with the given slug.
+	 *
+	 * @param string $slug The board slug.
+	 * @param string $name The board name.
+	 * @return int The board term ID.
+	 */
+	private function create_board_with_slug( string $slug, string $name ): int {
+		return self::factory()->board->create(
+			array(
+				'name' => $name,
+				'slug' => $slug,
+			)
+		);
+	}
+
+	/**
+	 * Returns the decker_board term IDs assigned to a task.
+	 *
+	 * @param int $task_id The task ID.
+	 * @return int[] The board term IDs.
+	 */
+	private function get_task_board_ids( int $task_id ): array {
+		return wp_get_post_terms( $task_id, 'decker_board', array( 'fields' => 'ids' ) );
+	}
+
+	/**
+	 * Counts the existing decker_task posts in any status.
+	 *
+	 * @return int The number of tasks.
+	 */
+	private function count_decker_tasks(): int {
+		$tasks = get_posts(
+			array(
+				'post_type'   => 'decker_task',
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			)
+		);
+
+		return count( $tasks );
+	}
+
+	/**
+	 * Dispatches the email-to-post endpoint with the given raw e-mail and metadata subject.
+	 *
+	 * The endpoint derives the task title from metadata.subject, so callers control the
+	 * effective subject (and any board directive) through the $subject argument.
+	 *
+	 * @param string $raw_email The raw e-mail content.
+	 * @param string $subject   The metadata subject used as the task title source.
+	 * @return WP_REST_Response The REST response.
+	 */
+	private function dispatch_raw_email_with_subject( string $raw_email, string $subject ) {
+		$request = new WP_REST_Request( 'POST', $this->endpoint );
+		$request->add_header( 'Authorization', 'Bearer ' . $this->shared_key );
+		$request->add_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			json_encode(
+				array(
+					'rawEmail' => base64_encode( $raw_email ),
+					'metadata' => array(
+						'from'    => 'test@example.com',
+						'to'      => 'decker@example.com',
+						'subject' => $subject,
+						'cc'      => array(),
+						'bcc'     => array(),
+					),
+				)
+			)
+		);
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Dispatches a simple plain-text e-mail using the given subject.
+	 *
+	 * @param string $subject The metadata subject used as the task title source.
+	 * @param string $body    The plain-text body.
+	 * @return WP_REST_Response The REST response.
+	 */
+	private function dispatch_email_with_subject( string $subject, string $body = 'This is a test task body' ) {
+		$raw_email  = "From: test@example.com\r\n";
+		$raw_email .= "To: decker@example.com\r\n";
+		$raw_email .= 'Subject: ' . $subject . "\r\n";
+		$raw_email .= "Content-Type: text/plain\r\n\r\n";
+		$raw_email .= $body;
+
+		return $this->dispatch_raw_email_with_subject( $raw_email, $subject );
+	}
+
+	/**
 	 * Helper method to retrieve fixture content.
 	 *
 	 * @param string $filename Name of the fixture file.


### PR DESCRIPTION
## Summary

Adds subject-based **board routing** for tasks created through the email-to-post endpoint (`POST /decker/v1/email-to-post`).

A board directive at the **start** of the email subject routes the task to the matching `decker_board`, and the directive is stripped from the stored title:

```text
[soe] pepito pérez          ->  board "soe",  title "pepito pérez"
[board:soe] pepito pérez    ->  board "soe",  title "pepito pérez"
[tablero:soe] pepito pérez  ->  board "soe",  title "pepito pérez"
```

`#` is intentionally **not** used for boards — it is reserved for labels/tags (`decker_label`).

## Behavior

- Matching is **case-insensitive**, normalized with `sanitize_title()` (`[SOE]` → `soe`), and is by board **slug** (never by display name).
- **No directive** → unchanged: the sender's `decker_default_board` is used.
- **Bare `[xxx]` that matches no board** → graceful fallback to the default board, **keeping the bracket in the title** (e.g. `[URGENT] Fix login` still creates a task). This avoids silently dropping legitimate bracketed subject prefixes (ticket IDs, `[EXTERNAL]`, mailing-list `[list-name]` tags, …).
- **Explicit `[board:slug]` / `[tablero:slug]` with no matching board** → `WP_Error( 'invalid_board_slug' )`, **HTTP 400**, no task created (explicit routing intent fails loudly rather than misfiling).
- **Directive that leaves no title** (e.g. `[soe]`) → `WP_Error( 'missing_field' )`, **HTTP 400**, no task created.
- **Unchanged:** attachment handling, authorization, sender validation, the initial `to-do` stack, and the `+3 days` due date.

| Subject | Result |
| --- | --- |
| `[soe] hi` | board `soe`, title `hi` |
| `[board:soe] hi` / `[tablero:soe] hi` | board `soe`, title `hi` |
| `[URGENT] fix` (no `urgent` board) | **default** board, title `[URGENT] fix` |
| `[board:zzz] hi` (no `zzz` board) | HTTP 400 `invalid_board_slug` |
| `[soe]` (no title) | HTTP 400 `missing_field` |
| `plain subject` | default board, title `plain subject` |

## Implementation

`Decker_Email_To_Post::create_task()` now delegates board/title resolution to small, focused helpers in `includes/class-decker-email-to-post.php`:

- `resolve_board_and_subject_from_email()` — orchestrates directive parsing, board resolution, the graceful-fallback vs. fail-loud policy, and the error contracts.
- `parse_board_directive_from_subject()` — extracts the optional `[slug]` / `[board:slug]` / `[tablero:slug]` directive, reports whether an explicit qualifier was used, and returns both the stripped title and the original (fallback) title.
- `get_board_by_slug()` — looks up a `decker_board` term by slug.
- `get_default_board_for_user()` — preserves the legacy default-board lookup and its existing error contract.

Legacy colon syntax (`SOE: title`) is intentionally **out of scope** to avoid ambiguity with mail prefixes such as `RE:` / `FW:`.

## Testing

- `make test FILE=tests/unit/includes/DeckerEmailToPostTest.php` → 27 tests, all green (12 routing tests).
- Full suite: **no regressions**.
- `phpcs --standard=WordPress` clean on the production file and across the project gate.

New PHPUnit coverage (`tests/unit/includes/DeckerEmailToPostTest.php`): bracket routing, `board:` / `tablero:` qualifiers, case-insensitivity, slug-vs-name discrimination, default-board fallback, **unmatched bare-bracket graceful fallback**, empty-slug fallback, whitespace tolerance, invalid explicit slug (400), empty title (400), and an attachment-regression guard.

Closes #264.
