### PR TITLE
fix(rest): register task detail meta (stack, max_priority, duedate)

### DIFF
--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -2084,6 +2084,70 @@ class Decker_Tasks {
 		);
 
 		register_post_type( 'decker_task', $args );
+
+		$this->register_task_meta();
+	}
+
+	/**
+	 * Register the task detail meta fields for the REST API.
+	 *
+	 * The `decker_task` post type is exposed over REST, but its detail meta was
+	 * not registered, so the generic `/wp/v2/tasks` endpoint silently dropped
+	 * `stack`, `max_priority` and `duedate` on write and never returned them on
+	 * read. Registering them here makes those fields round-trip through REST.
+	 *
+	 * Writing the `stack` meta stays ordering-consistent because the existing
+	 * `added_post_meta` / `updated_post_meta` hooks recompute the task order.
+	 */
+	private function register_task_meta() {
+		$auth_callback = function ( $allowed, $meta_key, $post_id ) {
+			return current_user_can( 'edit_post', $post_id );
+		};
+
+		// `stack` is validated with a REST enum schema rather than a
+		// sanitize_callback so that only REST writes are constrained; internal
+		// meta writes (form save, drag-and-drop reorder) keep their raw values.
+		register_post_meta(
+			'decker_task',
+			'stack',
+			array(
+				'type'          => 'string',
+				'single'        => true,
+				'auth_callback' => $auth_callback,
+				'show_in_rest'  => array(
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( 'to-do', 'in-progress', 'done' ),
+					),
+				),
+			)
+		);
+
+		// Stored internally as '0'/'1' (and '' for legacy rows); the model reads
+		// it as `'1' === value`. Exposed as a boolean over REST without a
+		// value-altering sanitize_callback so internal writes are untouched.
+		register_post_meta(
+			'decker_task',
+			'max_priority',
+			array(
+				'type'          => 'boolean',
+				'single'        => true,
+				'show_in_rest'  => true,
+				'auth_callback' => $auth_callback,
+			)
+		);
+
+		register_post_meta(
+			'decker_task',
+			'duedate',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'auth_callback'     => $auth_callback,
+				'sanitize_callback' => 'sanitize_text_field',
+			)
+		);
 	}
 
 	/**

--- a/tests/integration/DeckerTaskRestMetaTest.php
+++ b/tests/integration/DeckerTaskRestMetaTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests that task detail meta round-trips through the REST API.
+ *
+ * Regression coverage for the endpoint silently dropping `stack`,
+ * `max_priority` and `duedate` because they were not registered for REST.
+ *
+ * @package Decker
+ */
+class DeckerTaskRestMetaTest extends Decker_Test_Base {
+
+	private $user_id;
+	private $board_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->user_id );
+
+		// WP_UnitTestCase::tear_down() unregisters every meta key after each
+		// test, so re-fire `init` to restore the plugin's REST meta registration
+		// (in production `init` runs once and the meta stays registered).
+		do_action( 'init' );
+
+		$this->board_id = self::factory()->board->create( array( 'name' => 'REST Meta Board' ) );
+	}
+
+	/**
+	 * Creating a task over REST persists its detail meta and returns it.
+	 */
+	public function test_meta_is_written_and_returned_on_create() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/tasks' );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
+		$request->set_body_params(
+			array(
+				'title'        => 'REST Meta Task',
+				'status'       => 'publish',
+				'decker_board' => array( $this->board_id ),
+				'meta'         => array(
+					'stack'        => 'in-progress',
+					'max_priority' => true,
+					'duedate'      => '2026-12-31',
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 201, $response->get_status(), 'Task was not created via REST.' );
+
+		$data    = $response->get_data();
+		$task_id = $data['id'];
+
+		// Persisted to post meta.
+		$this->assertEquals( 'in-progress', get_post_meta( $task_id, 'stack', true ) );
+		$this->assertEquals( '1', get_post_meta( $task_id, 'max_priority', true ) );
+		$this->assertEquals( '2026-12-31', get_post_meta( $task_id, 'duedate', true ) );
+
+		// Exposed in the REST response (max_priority is a boolean over REST).
+		$this->assertEquals( 'in-progress', $data['meta']['stack'] );
+		$this->assertTrue( $data['meta']['max_priority'] );
+		$this->assertEquals( '2026-12-31', $data['meta']['duedate'] );
+
+		// The Task model reads the same values.
+		$task = new Task( $task_id );
+		$this->assertEquals( 'in-progress', $task->stack );
+		$this->assertTrue( $task->max_priority );
+	}
+
+	/**
+	 * Updating the stack over REST persists the new value.
+	 */
+	public function test_stack_can_be_updated_via_rest() {
+		$task_id = self::factory()->task->create(
+			array(
+				'board' => $this->board_id,
+				'stack' => 'to-do',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/tasks/%d', $task_id ) );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
+		$request->set_body_params( array( 'meta' => array( 'stack' => 'done' ) ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		// The new value is persisted. Reorder hooks run raw SQL on stack
+		// changes, so drop the in-request meta cache before asserting.
+		clean_post_cache( $task_id );
+		$this->assertEquals( 'done', get_post_meta( $task_id, 'stack', true ) );
+	}
+
+	/**
+	 * An invalid stack value is rejected by the REST enum schema and the stored
+	 * value is left unchanged.
+	 */
+	public function test_invalid_stack_is_rejected() {
+		$task_id = self::factory()->task->create(
+			array(
+				'board' => $this->board_id,
+				'stack' => 'to-do',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/tasks/%d', $task_id ) );
+		$request->set_header( 'X-WP-Nonce', wp_create_nonce( 'wp_rest' ) );
+		$request->set_body_params( array( 'meta' => array( 'stack' => 'not-a-real-stack' ) ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+
+		clean_post_cache( $task_id );
+		$this->assertEquals( 'to-do', get_post_meta( $task_id, 'stack', true ) );
+	}
+}


### PR DESCRIPTION
Fixes #272.

## Problem

The `decker_task` post type is exposed over REST (`show_in_rest => true`, `rest_base => tasks`), but its detail meta — `stack`, `max_priority`, `duedate` — was never registered with `register_post_meta( … 'show_in_rest' => true )`. As a result the `/wp/v2/tasks` endpoint **silently dropped** those fields on write and never returned them on read. Because the model defaults an unset stack to `null`, a REST-created task ended up in a non-rendered column and appeared in **no** Kanban column.

## Fix

Register the three meta fields on `init` (via `register_post_type()`):

- **`stack`** — validated with a REST `enum` schema (`to-do` / `in-progress` / `done`). Using a schema (instead of a `sanitize_callback`) means only REST writes are constrained; internal meta writes (form save, drag-and-drop reorder) keep their raw values untouched. An invalid stack over REST is rejected with `400`.
- **`max_priority`** — exposed as a `boolean` over REST, but kept as the existing `'0'`/`'1'` string that the `Task` model reads (`'1' === $value`). No value-altering `sanitize_callback`, so internal writes still store `'0'`/`'1'` exactly as before.
- **`duedate`** — `string`, sanitized with `sanitize_text_field`.

The existing `added_post_meta` / `updated_post_meta` → `handle_stack_change_reorder` hooks already recompute `menu_order` when the stack meta changes, so REST writes to `stack` stay ordering-consistent.

Drag-and-drop stack changes keep using their dedicated endpoint (`decker/v1/tasks/{id}/stack`); this only makes the generic task meta writable/readable over `/wp/v2/tasks`.

## Tests

Adds `tests/integration/DeckerTaskRestMetaTest.php`:

- create persists and returns `stack`/`max_priority`/`duedate`,
- stack can be updated over REST,
- an invalid stack is rejected by the enum schema.

Full suite: **603 passed** (`make test`); `phpcs` clean.

## Notes

Surfaced while enabling the E2E suite in CI (#204), where REST-created test tasks couldn't control their stack/priority/due date.
