### PR TITLE
fix(locks): invalidate editing sessions on out-of-band task mutations

### DIFF
--- a/docs/adr/001-task-edit-concurrency.md
+++ b/docs/adr/001-task-edit-concurrency.md
@@ -41,6 +41,10 @@ race. The cost grew to 4 lock classes, ~1050 LOC and ~65 lock tests.
 > generation token its form rendered with. If the task's current token
 > differs — or another user holds a fresh advisory lock — the save is
 > rejected with HTTP 409 and the user is told to reload.
+>
+> Because the editor form resubmits the *whole* task, any mutation that
+> reaches a card outside that form must rotate the generation, so a form
+> rendered before it cannot silently revert it.
 
 Mechanism (state: one meta key `_decker_edit_lock_state` =
 `{"user":int,"token":"uuid","time":int}`; two small classes):
@@ -50,32 +54,62 @@ Mechanism (state: one meta key `_decker_edit_lock_state` =
   mirrored for wp-admin interop. Plain meta writes, exactly like core.
 - **Generation token**: minted on ownership change / explicit takeover; kept
   after release (`time = 0`) so a stale form stays invalid after the winner
-  leaves; **rotated on each successful save** so any other stale form
-  (including a second tab of the same user) is rejected on its next save.
-- Enforcement points: the AJAX save, the generic `/wp/v2/tasks/{id}` REST
-  update (`rest_pre_insert_decker_task`), and the heartbeat (flags
+  leaves; **rotated on every committed mutation of the task** so any other
+  stale form (including a second tab of the same user) is rejected on its
+  next save.
+- Enforcement points (reject): the AJAX save, the generic `/wp/v2/tasks/{id}`
+  REST update (`rest_pre_insert_decker_task`), and the heartbeat (flags
   `stale_session` so the UI blocks the stale editor immediately).
+- Rotation points (invalidate): the AJAX save, the generic REST update
+  (`rest_after_insert_decker_task`), and every out-of-band mutating endpoint —
+  `/order`, `/stack`, `/assign`, `/leave`, `/update_due_date`, `/merge` — via
+  `Decker_Task_Locks::invalidate_sessions()`, which rotates the token while
+  preserving the owner and timestamp. Rotation is a no-op on a never-locked
+  task, so tokenless internal writes keep working.
+
+  Consequence, accepted deliberately: moving a card someone has open makes
+  their next save return 409 and ask for a reload. A visible reload beats a
+  silent revert, and the alternative — refusing the drag while a card is open
+  — would break the board's normal workflow.
 
 Serialising concurrent writes (leases, CAS, write-time re-checks) is **out of
 scope**: the requirement is "no user's edits are silently overwritten by a
 stale form", where "stale" means minutes-to-hours old — human timescales.
-Sub-second interleavings are not stale forms; at 17 users their expected
-frequency is well below one per decade, and revisions recover them.
+Sub-second interleavings are not stale forms. At 17 users we judge them
+*very unlikely* — they need two people writing the same card within the same
+request — and partially recoverable. These are qualitative judgements from
+the team's observed usage, not measured rates; we have no instrumentation for
+concurrent writes. Treat the column below as an ordering of plausibility, not
+as frequencies.
 
 ## Accepted residual risks
 
-| # | Residual race | Window | Est. frequency @ 17 users | Consequence | Recovery |
+| # | Residual race | Window | Plausibility @ 17 users (qualitative) | Consequence | Recovery |
 |---|---|---|---|---|---|
-| 1 | Takeover lands between a save's token validation and its `wp_update_post()` | ~tens of ms, requires a takeover in that exact window | ≪ 1/decade | The pre-takeover save commits; the taker starts from it or overwrites it | Revisions (title/desc); meta fixed by the taker, who is looking at the card |
-| 2 | Two saves presenting the **same** valid token commit concurrently (double-submit, two same-user tabs racing) | ~request duration | ≪ 1/year (client disables Save while submitting) | Last write wins between the same user's own sessions | Revisions (title/desc); meta re-entered by the same user |
-| 3 | Two lock operations (acquire/takeover) write lock state in the same instant | ~ms | ≪ 1/year | One lock write lost; state self-heals on next heartbeat (≤ 15 s) | None needed; content is never affected |
-| 4 | Concurrent **first** lock writes on a never-locked task duplicate the meta row | ~ms, first lock only | ≪ 1/decade | Redundant meta row; behaviour unchanged (single `get_post_meta` reads one row) | Delete the extra row if ever noticed |
+| 1 | Takeover lands between a save's token validation and its `wp_update_post()` | ~tens of ms, requires a takeover in that exact window | very unlikely | The pre-takeover save commits; the taker starts from it or overwrites it | Revisions (title/desc); meta fixed by the taker, who is looking at the card |
+| 2 | Two saves presenting the **same** valid token commit concurrently (double-submit, two same-user tabs racing) | ~request duration | unlikely (client disables Save while submitting) | Last write wins between the same user's own sessions | Revisions (title/desc); meta re-entered by the same user |
+| 3 | Two lock operations (acquire/takeover) write lock state in the same instant | ~ms | unlikely | One lock write lost; state self-heals on next heartbeat (≤ 15 s) | None needed; content is never affected |
+| 4 | Concurrent **first** lock writes on a never-locked task duplicate the meta row | ~ms, first lock only | very unlikely | Redundant meta row; behaviour unchanged (single `get_post_meta` reads one row) | Delete the extra row if ever noticed |
 | 5 | wp-admin classic-editor save ignores the generation (core has no enforcement hook there) | n/a | rare (team uses the Decker UI) | Same protection level as every other WordPress post type | Revisions (title/desc); meta by hand |
+| 6 | `_edit_lock` interop is one-way: `active_lock()` only consults the native lock when the Decker state is inactive, and the mirror is cleared by owner id without comparing timestamps | n/a | rare (Gutenberg is disabled for `decker_task`; the team edits in the Decker UI) | A wp-admin takeover is not seen by Decker, and A's next heartbeat overwrites it | Reload; do not treat this as full native-editor interop |
 
-If any of these is ever observed more than ~once a year in practice, the
-first escalation is **not** a lease: it is `GET_LOCK`/`SELECT ... FOR UPDATE`
+If any of these is ever observed in practice — even once — the first
+escalation is **not** a lease: it is `GET_LOCK`/`SELECT ... FOR UPDATE`
 around the save endpoint, or moving the team to the collaborative-editing
 mode (CRDT) that already ships in Decker and stands the lock down entirely.
+
+Note for whoever reaches for `GET_LOCK`: it is connection-scoped. That is
+fine in production under PHP-FPM, where each request gets its own connection,
+but it cannot be exercised by the in-process concurrency our PHPUnit suite
+injects. Budget for an integration harness with real parallel requests, or
+the mechanism will look untestable and get replaced by an in-state lease
+again.
+
+Revisions recover `post_title` and `post_content` only. Everything Decker
+keeps in post meta — stack, board, assignees, labels, due date, priority — is
+**not** revisioned and must be re-entered by hand. In each residual above the
+person who would re-enter it is already looking at the card, which is why we
+accept it; but "revisions recover it" is not true of a whole task.
 
 ## Consequences
 

--- a/includes/class-decker-task-locks.php
+++ b/includes/class-decker-task-locks.php
@@ -289,6 +289,36 @@ class Decker_Task_Locks {
 	}
 
 	/**
+	 * Invalidate every open editing session for a task.
+	 *
+	 * Mutations that reach a task outside the editor form (moving a card between
+	 * stacks, assigning a user, changing the due date, merging) leave any open
+	 * form holding data that is now stale. Those forms resubmit the whole task,
+	 * so without this the next save silently reverts the change.
+	 *
+	 * Rotating the token here turns that save into a 409 the client already
+	 * handles: the editor is told the card changed instead of overwriting it.
+	 * The lock owner and timestamp are preserved, so whoever is editing keeps
+	 * the lock and only has to reload.
+	 *
+	 * No-ops when the task was never locked (there is no session to invalidate).
+	 *
+	 * @param int $post_id The task post ID.
+	 * @return string|false The new generation, or false when nothing was rotated.
+	 */
+	public function invalidate_sessions( int $post_id ) {
+		$state = $this->state->read( $post_id );
+		if ( ! is_array( $state ) || '' === (string) $state['token'] ) {
+			return false;
+		}
+
+		$token = wp_generate_uuid4();
+		$this->state->save( $post_id, (int) $state['user'], $token, (int) $state['time'] );
+
+		return $token;
+	}
+
+	/**
 	 * Rotate the session generation after a successful save.
 	 *
 	 * A successful save rotates the token so any other form still holding the old

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -95,6 +95,9 @@ class Decker_Tasks {
 		// Enforce the edit lock (detect-and-reject) on generic /wp/v2/tasks
 		// updates, which bypass the save_decker_task guard.
 		add_filter( 'rest_pre_insert_decker_task', array( $this, 'guard_rest_task_update' ), 10, 2 );
+		// A generic REST update also supersedes every open form, so rotate the
+		// generation afterwards exactly like an AJAX save does.
+		add_action( 'rest_after_insert_decker_task', array( $this, 'rotate_generation_after_rest_update' ), 10, 3 );
 		add_filter( 'manage_decker_task_posts_columns', array( $this, 'add_custom_columns' ) );
 		add_action( 'manage_decker_task_posts_custom_column', array( $this, 'render_custom_columns' ), 10, 2 );
 		add_filter( 'manage_edit-decker_task_sortable_columns', array( $this, 'make_columns_sortable' ) );
@@ -333,6 +336,9 @@ class Decker_Tasks {
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
+
+		// The card moved: any open editor form now holds a stale stack.
+		$this->get_task_locks()->invalidate_sessions( $task_id );
 
 		return new WP_REST_Response(
 			array(
@@ -1229,6 +1235,14 @@ class Decker_Tasks {
 
 		$result = self::merge_tasks( $source_task_id, $destination_task_id );
 
+		if ( ! is_wp_error( $result ) ) {
+			// The destination absorbed content: invalidate any open editor form
+			// on either side of the merge.
+			$locks = $this->get_task_locks();
+			$locks->invalidate_sessions( $source_task_id );
+			$locks->invalidate_sessions( $destination_task_id );
+		}
+
 		if ( is_wp_error( $result ) ) {
 			$error_data = $result->get_error_data();
 			$status     = is_array( $error_data ) && isset( $error_data['status'] )
@@ -1812,6 +1826,8 @@ class Decker_Tasks {
 			// Trigger a hook after a user has been assigned.
 			do_action( 'decker_user_assigned', $task_id, $user_id );
 
+			// Assignees changed: invalidate any open editor form.
+			$this->get_task_locks()->invalidate_sessions( $task_id );
 		}
 
 		return new WP_REST_Response(
@@ -1858,6 +1874,9 @@ class Decker_Tasks {
 		if ( is_array( $assigned_users ) && in_array( $user_id, $assigned_users ) ) {
 			$assigned_users = array_diff( $assigned_users, array( $user_id ) );
 			update_post_meta( $task_id, 'assigned_users', $assigned_users );
+
+			// Assignees changed: invalidate any open editor form.
+			$this->get_task_locks()->invalidate_sessions( $task_id );
 		}
 
 		return new WP_REST_Response(
@@ -1960,6 +1979,11 @@ class Decker_Tasks {
 		}
 
 		do_action( 'decker_task_updated', $task_id ); // Invalidates .ics “all”.
+
+		if ( ! empty( $updated_meta ) ) {
+			// The due date changed: invalidate any open editor form.
+			$this->get_task_locks()->invalidate_sessions( $task_id );
+		}
 
 		 // Step 4: Return response.
 		return new WP_REST_Response(
@@ -2828,6 +2852,26 @@ class Decker_Tasks {
 		}
 
 		return $prepared_post;
+	}
+
+	/**
+	 * Invalidate open editing sessions after a generic REST update.
+	 *
+	 * `guard_rest_task_update()` only validates the submitted generation before
+	 * the write. Without this the token stays reusable, so a stale form (or a
+	 * second REST client of the same user) could still overwrite the update.
+	 *
+	 * @param WP_Post         $post     The task that was written.
+	 * @param WP_REST_Request $request  The REST request.
+	 * @param bool            $creating Whether the post was just created.
+	 * @return void
+	 */
+	public function rotate_generation_after_rest_update( $post, $request, $creating ) {
+		if ( $creating || ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		$this->get_task_locks()->invalidate_sessions( (int) $post->ID );
 	}
 
 	/**

--- a/tests/integration/DeckerTaskOutOfBandMutationLockTest.php
+++ b/tests/integration/DeckerTaskOutOfBandMutationLockTest.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Integration tests for edit-session invalidation on out-of-band mutations.
+ *
+ * The editor form resubmits the whole task (stack, board, due date, assignees,
+ * labels). Endpoints that mutate a card outside that form therefore leave any
+ * open form holding stale data, and the next save would silently revert them.
+ *
+ * These tests prove each such endpoint rotates the lock generation, so the
+ * stale save is rejected with 409 instead of overwriting the change.
+ *
+ * @package Decker
+ */
+
+/**
+ * Class DeckerTaskOutOfBandMutationLockTest
+ */
+class DeckerTaskOutOfBandMutationLockTest extends Decker_Test_Base {
+
+	/**
+	 * The editor holding the open form.
+	 *
+	 * @var int
+	 */
+	private $user_a;
+
+	/**
+	 * The user mutating the card from elsewhere.
+	 *
+	 * @var int
+	 */
+	private $user_b;
+
+	/**
+	 * Board fixture.
+	 *
+	 * @var int
+	 */
+	private $board_id;
+
+	/**
+	 * Task fixture.
+	 *
+	 * @var int
+	 */
+	private $task_id;
+
+	/**
+	 * Lock manager.
+	 *
+	 * @var Decker_Task_Locks
+	 */
+	private $locks;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		do_action( 'init' );
+
+		$this->user_a = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$this->user_b = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $this->user_a );
+
+		$this->board_id = self::factory()->board->create();
+		$this->task_id  = self::factory()->task->create(
+			array(
+				'post_title' => 'Original title',
+				'board'      => $this->board_id,
+				'stack'      => 'to-do',
+			)
+		);
+
+		$this->locks = new Decker_Task_Locks();
+
+		// Make handle_save_decker_task() return its payload instead of dying.
+		add_filter( 'decker_save_task_send_response', '__return_false' );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		remove_filter( 'decker_save_task_send_response', '__return_false' );
+		$_POST = array();
+		wp_delete_user( $this->user_a );
+		wp_delete_user( $this->user_b );
+		parent::tear_down();
+	}
+
+	/**
+	 * Open the editor form as user A and return its session generation.
+	 *
+	 * @return string The generation embedded in A's form.
+	 */
+	private function open_form_as_a(): string {
+		wp_set_current_user( $this->user_a );
+		$info = $this->locks->acquire_lock( $this->task_id, $this->user_a );
+
+		return (string) $info['generation'];
+	}
+
+	/**
+	 * Submit A's form with the generation it was rendered with.
+	 *
+	 * @param string $generation The generation A's form is carrying.
+	 * @param string $stack      The stack A's form resubmits.
+	 * @return array The save response payload.
+	 */
+	private function save_as_a( string $generation, string $stack = 'to-do' ): array {
+		wp_set_current_user( $this->user_a );
+
+		$_POST = array(
+			'task_id'         => $this->task_id,
+			'title'           => 'Saved from a form opened earlier',
+			'stack'           => $stack,
+			'board'           => $this->board_id,
+			'lock_generation' => $generation,
+		);
+
+		return ( new Decker_Tasks() )->handle_save_decker_task();
+	}
+
+	/**
+	 * Assert a save response is the lock-conflict rejection.
+	 *
+	 * @param array $response The save response payload.
+	 * @return void
+	 */
+	private function assertStaleSaveRejected( array $response ) {
+		$this->assertFalse( $response['success'], 'The stale save should have been rejected.' );
+		$this->assertSame( 'decker_task_locked', $response['code'] );
+	}
+
+	/**
+	 * Move the card between stacks through the order/stack controller.
+	 *
+	 * @param string $target_stack The stack to drop the card on.
+	 * @return WP_REST_Response The controller response.
+	 */
+	private function move_card_as_b( string $target_stack ) {
+		wp_set_current_user( $this->user_b );
+
+		$request = new WP_REST_Request( 'PUT', '/decker/v1/tasks/' . $this->task_id . '/stack' );
+		$request->set_url_params( array( 'id' => $this->task_id ) );
+		$request->set_param( 'board_id', $this->board_id );
+		$request->set_param( 'source_stack', 'to-do' );
+		$request->set_param( 'target_stack', $target_stack );
+		$request->set_param( 'source_order', 1 );
+		$request->set_param( 'target_order', 1 );
+
+		return ( new Decker_Tasks() )->update_task_stack_and_order( $request );
+	}
+
+	/**
+	 * The regression this PR exists for: B moves a card, A's older form must not
+	 * be able to drag it back by resubmitting its stale stack.
+	 */
+	public function test_stack_change_invalidates_an_open_form() {
+		$generation = $this->open_form_as_a();
+
+		$this->move_card_as_b( 'in-progress' );
+
+		$this->assertNotSame(
+			$generation,
+			$this->current_generation(),
+			'Moving the card should have rotated the generation.'
+		);
+
+		$this->assertStaleSaveRejected( $this->save_as_a( $generation ) );
+
+		$this->assertSame(
+			'in-progress',
+			$this->get_stack( $this->task_id ),
+			"A's stale save must not revert the card to its previous stack."
+		);
+		$this->assertSame( 'Original title', get_post( $this->task_id )->post_title );
+	}
+
+	/**
+	 * Assigning a user invalidates an open form, which would otherwise resubmit
+	 * the assignee list it was rendered with.
+	 */
+	public function test_assign_invalidates_an_open_form() {
+		$generation = $this->open_form_as_a();
+
+		wp_set_current_user( $this->user_b );
+		$request = new WP_REST_Request( 'POST', '/decker/v1/tasks/' . $this->task_id . '/assign' );
+		$request->set_url_params( array( 'id' => $this->task_id ) );
+		$request->set_param( 'user_id', $this->user_b );
+		( new Decker_Tasks() )->assign_user_to_task( $request );
+
+		$this->assertNotSame( $generation, $this->current_generation() );
+		$this->assertStaleSaveRejected( $this->save_as_a( $generation ) );
+	}
+
+	/**
+	 * Removing a user invalidates an open form.
+	 */
+	public function test_leave_invalidates_an_open_form() {
+		update_post_meta( $this->task_id, 'assigned_users', array( $this->user_b ) );
+
+		$generation = $this->open_form_as_a();
+
+		wp_set_current_user( $this->user_b );
+		$request = new WP_REST_Request( 'POST', '/decker/v1/tasks/' . $this->task_id . '/leave' );
+		$request->set_url_params( array( 'id' => $this->task_id ) );
+		$request->set_param( 'user_id', $this->user_b );
+		( new Decker_Tasks() )->remove_user_from_task( $request );
+
+		$this->assertNotSame( $generation, $this->current_generation() );
+		$this->assertStaleSaveRejected( $this->save_as_a( $generation ) );
+	}
+
+	/**
+	 * Changing the due date invalidates an open form.
+	 */
+	public function test_due_date_change_invalidates_an_open_form() {
+		$generation = $this->open_form_as_a();
+
+		wp_set_current_user( $this->user_b );
+		$request = new WP_REST_Request( 'PUT', '/decker/v1/tasks/' . $this->task_id . '/update_due_date' );
+		$request->set_url_params( array( 'id' => $this->task_id ) );
+		$request->set_param( 'id', $this->task_id );
+		$request->set_param( 'duedate', '2026-12-31' );
+		( new Decker_Tasks() )->update_task_due_date( $request );
+
+		$this->assertNotSame( $generation, $this->current_generation() );
+		$this->assertStaleSaveRejected( $this->save_as_a( $generation ) );
+	}
+
+	/**
+	 * A generic REST update rotates the generation too, so the token cannot be
+	 * replayed by a stale form or a second REST client of the same user.
+	 */
+	public function test_generic_rest_update_rotates_the_generation() {
+		$generation = $this->open_form_as_a();
+
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/tasks/%d', $this->task_id ) );
+		$request->set_param( 'title', 'Updated over generic REST' );
+		$request->set_param( 'lock_generation', $generation );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status(), (string) wp_json_encode( $response->get_data() ) );
+		$this->assertNotSame(
+			$generation,
+			$this->current_generation(),
+			'A successful REST update should rotate the generation.'
+		);
+
+		$this->assertStaleSaveRejected( $this->save_as_a( $generation ) );
+	}
+
+	/**
+	 * Invalidation must not steal the lock: whoever is editing keeps ownership
+	 * and only has to reload, rather than losing the card to a passing drag.
+	 */
+	public function test_invalidation_preserves_the_lock_owner() {
+		$this->open_form_as_a();
+		$before = $this->locks->get_lock_info( $this->task_id, $this->user_b );
+
+		$this->move_card_as_b( 'in-progress' );
+
+		$after = $this->locks->get_lock_info( $this->task_id, $this->user_b );
+
+		$this->assertTrue( $before['locked'], 'A should hold the lock before the move.' );
+		$this->assertTrue( $after['locked'], 'A should still hold the lock after the move.' );
+		$this->assertSame( $this->user_a, (int) $after['owner']['id'] );
+	}
+
+	/**
+	 * A never-locked task has no session to invalidate, so out-of-band mutations
+	 * must not start handing out generations that later saves would then need.
+	 */
+	public function test_never_locked_task_is_not_given_a_generation() {
+		$this->assertSame( '', $this->current_generation() );
+
+		$this->move_card_as_b( 'in-progress' );
+
+		$this->assertSame(
+			'',
+			$this->current_generation(),
+			'Mutating a never-locked task must not mint a generation.'
+		);
+
+		// A save with no token still works, as it did before this change.
+		wp_set_current_user( $this->user_a );
+		$_POST = array(
+			'task_id' => $this->task_id,
+			'title'   => 'Saved without a lock',
+			'stack'   => 'in-progress',
+			'board'   => $this->board_id,
+		);
+
+		$response = ( new Decker_Tasks() )->handle_save_decker_task();
+
+		$this->assertTrue( $response['success'] );
+	}
+
+	/**
+	 * Read the authoritative generation token straight from the stored state.
+	 *
+	 * @return string The current generation, or an empty string when never locked.
+	 */
+	private function current_generation(): string {
+		return ( new Decker_Task_Lock_State() )->generation( $this->task_id );
+	}
+
+	/**
+	 * Read the current stack term of a task.
+	 *
+	 * @param int $task_id The task post ID.
+	 * @return string The stack slug, or an empty string.
+	 */
+	private function get_stack( int $task_id ): string {
+		$stack = get_post_meta( $task_id, 'stack', true );
+
+		return is_string( $stack ) ? $stack : '';
+	}
+}


### PR DESCRIPTION
Follow-up to #277.

## Problem

The generation token only guarded the editor form save path, but a card can be mutated from six other endpoints that neither check nor rotate it. Since the editor form resubmits the whole task, a form opened before one of those mutations silently reverted it on its next save — no race needed, the window is minutes:

1. A opens a card (form carries token X)
2. B moves it to another column via `/stack`
3. A saves the old form → accepted, the token was never rotated
4. The card returns to its old column — B's move is silently lost

Same applies to `/order`, `/assign`, `/leave`, `/update_due_date` and `/merge`.

## Fix

- New `Decker_Task_Locks::invalidate_sessions()`: rotates the generation token while preserving the lock owner and timestamp. No-op on never-locked tasks, so tokenless internal writes are unaffected.
- Called from every mutating endpoint: `/order`, `/stack`, `/assign`, `/leave`, `/update_due_date` and `/merge` (both sides).
- Generic REST updates now rotate too (`rest_after_insert_decker_task`): previously the token was validated before the write but stayed replayable.

A stale save now returns 409 and the client asks for a reload — a visible reload instead of a silent revert. Deliberate trade-off: moving a card someone has open makes their next save ask for a reload.

## Docs

Amends `docs/adr/001-task-edit-concurrency.md`: scopes the guarantee to what the code enforces, adds the one-way `_edit_lock` interop as residual #6, replaces the unfounded frequency figures with qualitative judgements, records that revisions recover title/content only (not task meta), and notes that `GET_LOCK` is connection-scoped.

## Tests

7 new integration tests in `DeckerTaskOutOfBandMutationLockTest`: each endpoint invalidates an open form (the stale save is rejected and the mutation survives), a generic REST update rotates the generation, invalidation does not steal the lock, and a never-locked task is not given a generation.

## Follow-up (separate issue)

Have the editor form submit only modified fields. A full-object PUT from a form with multiple partial writers is the root cause; rotation mitigates it, partial submit removes it.
