### PR TITLE
Prevent fork pull requests from running CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,14 @@ on:
     tags:
       - '*'
     branches:
-      - '*' 
+      - '*'
 
 permissions:
   contents: read
 
 jobs:
   lint_and_test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -30,6 +30,7 @@ permissions:
 jobs:
   PHPMD:
     name: Run PHPMD scanning
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read # for checkout to fetch code


### PR DESCRIPTION
## Summary

- skip the main CI workflow for pull requests originating from forks
- skip the PHPMD security scan for fork pull requests
- preserve pushes, scheduled scans, and same-repository pull requests

## Security rationale

The workflows install Composer and npm dependencies, start WordPress environments, run unit and Playwright tests, upload artifacts, and use `security-events: write` for SARIF results. Restricting fork-originated jobs prevents untrusted code from consuming runner resources or executing in a write-capable analysis job.