### PR TITLE
Restore CI for approved fork pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ permissions:
 
 jobs:
   lint_and_test:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       # Checkout the code

--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -30,7 +30,6 @@ permissions:
 jobs:
   PHPMD:
     name: Run PHPMD scanning
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read # for checkout to fetch code


### PR DESCRIPTION
## Summary

- revert the fork-specific CI and PHPMD restrictions introduced in #288
- allow normal pull request workflows to run after GitHub's external-contributor approval gate

## Rationale

The organization should use **Require approval for all external contributors**. This preserves manual approval while allowing maintainers to run CI for legitimate external contributions.