### PR TITLE
Reduce PHPMD codesize alerts from 25 to 20

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -53,6 +53,38 @@ do_action( 'decker_user_assigned', $task_id, $user_id );
 apply_filters( 'decker_save_task_send_response', true );
 ```
 
+## What counts as a stable surface
+
+The hooks above, plus `Decker_Tasks::create_or_update_task()`, are what integrations
+should build on. Everything else — class names, method names, which class registers
+which callback — is internal and gets reorganised as classes grow.
+
+Most public methods on these classes are public only because WordPress needs to call
+them as hook callbacks. Calling them directly, or unhooking them by name, is not
+supported.
+
+### Class reorganisations
+
+Symbols that have moved, so an integration that referenced the old location can find
+the new one. None of these changed behaviour; only their owner changed.
+
+| Was | Is now |
+| --- | --- |
+| `Decker_Boards::add_color_field()` / `edit_color_field()` / `save_color_meta()` | `Decker_Board_Term_Fields` (extends `Decker_Term_Color_Field`) |
+| `Decker_Labels::add_color_field()` / `edit_color_field()` / `save_color_meta()` | `Decker_Term_Color_Field` |
+| `Decker_Kb::track_last_editor()` / `get_last_editor()` / `get_latest_revision_id()` / `get_revision_admin_url()` | `Decker_Kb_Revisions` |
+| `Decker_Events::add_meta_boxes()` / `display_users_meta_box()` / `render_event_details_meta_box()` | `Decker_Event_Meta_Box` |
+| `Decker_Public::enqueue_scripts()` body | `Decker_Public_Assets` |
+
+Note that unhooking one of these by name fails **silently** rather than fatally:
+
+```php
+// No longer matches anything; the field still renders.
+remove_action( 'decker_board_add_form_fields', array( $boards, 'add_color_field' ) );
+```
+
+To suppress a field, unhook the current owner, or filter the markup it produces.
+
 ## Testing
 
 Tests live under `/tests/` and use factories.  

--- a/includes/class-decker-task-lock-presenter.php
+++ b/includes/class-decker-task-lock-presenter.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Describes task lock state to API consumers.
+ *
+ * Deciding who holds a lock is one job; deciding what a client is allowed to
+ * learn about it is another. This class owns the second: the public shape of a
+ * lock owner and the conflict error that carries it.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Task_Lock_Presenter
+ */
+class Decker_Task_Lock_Presenter {
+
+	/**
+	 * Build the public owner descriptor for a lock, or null when unavailable.
+	 *
+	 * Only the id and display name are exposed; private data such as the email
+	 * address is never included.
+	 *
+	 * @param int $owner_id The lock owner user ID.
+	 * @return array{id:int,display_name:string}|null The owner descriptor.
+	 */
+	public static function owner( int $owner_id ) {
+		if ( ! $owner_id ) {
+			return null;
+		}
+
+		$owner = get_userdata( $owner_id );
+		if ( ! $owner ) {
+			return null;
+		}
+
+		return array(
+			'id'           => $owner_id,
+			'display_name' => $owner->display_name,
+		);
+	}
+
+	/**
+	 * Build the standard `decker_task_locked` (409) error for a rejected save.
+	 *
+	 * @param string $message    Owner-specific message, or empty for the default takeover text.
+	 * @param mixed  $owner      The lock owner descriptor, or null.
+	 * @param string $generation The server generation to echo back.
+	 * @return WP_Error The lock-conflict error.
+	 */
+	public static function locked_error( string $message, $owner, string $generation ): WP_Error {
+		if ( '' === $message ) {
+			$message = __( 'You can no longer save this card because another user has taken over editing. Please reload the card to see the latest changes.', 'decker' );
+		}
+
+		return new WP_Error(
+			'decker_task_locked',
+			$message,
+			array(
+				'status'     => 409,
+				'owner'      => $owner,
+				'generation' => $generation,
+			)
+		);
+	}
+}

--- a/includes/class-decker-task-locks.php
+++ b/includes/class-decker-task-locks.php
@@ -135,7 +135,7 @@ class Decker_Task_Locks {
 			return $base;
 		}
 
-		$base['owner'] = $this->build_owner_info( $lock['user'] );
+		$base['owner'] = Decker_Task_Lock_Presenter::owner( $lock['user'] );
 
 		// A lock older than the window is stale and does not block a new editor.
 		if ( $lock['time'] <= ( time() - $this->get_lock_window() ) ) {
@@ -382,7 +382,7 @@ class Decker_Task_Locks {
 		$info = $this->get_lock_info( $post_id, $user_id );
 
 		if ( $info['locked'] ) {
-			return $this->locked_error( $info['message'], $info['owner'], $info['generation'] );
+			return Decker_Task_Lock_Presenter::locked_error( $info['message'], $info['owner'], $info['generation'] );
 		}
 
 		// A null or empty submitted generation both mean "no token" ('' cast).
@@ -390,7 +390,7 @@ class Decker_Task_Locks {
 
 		if ( $has_generation ) {
 			if ( (string) $session_generation !== $info['generation'] ) {
-				return $this->locked_error( $info['message'], $info['owner'], $info['generation'] );
+				return Decker_Task_Lock_Presenter::locked_error( $info['message'], $info['owner'], $info['generation'] );
 			}
 
 			return true;
@@ -402,7 +402,7 @@ class Decker_Task_Locks {
 		// never-locked task has no newer change to protect and stays saveable, so
 		// admin/meta and internal save paths keep working.
 		if ( $require_generation && '' !== $info['generation'] ) {
-			return $this->locked_error( '', $info['owner'], $info['generation'] );
+			return Decker_Task_Lock_Presenter::locked_error( '', $info['owner'], $info['generation'] );
 		}
 
 		return true;
@@ -421,30 +421,6 @@ class Decker_Task_Locks {
 		$token = $this->state->next_token( $state, $user_id, $bump );
 
 		$this->state->save( $post_id, $user_id, $token, time() );
-	}
-
-	/**
-	 * Build the standard `decker_task_locked` (409) error for a rejected save.
-	 *
-	 * @param string $message    Owner-specific message, or empty for the default takeover text.
-	 * @param mixed  $owner      The lock owner descriptor, or null.
-	 * @param string $generation The server generation to echo back.
-	 * @return WP_Error The lock-conflict error.
-	 */
-	private function locked_error( string $message, $owner, string $generation ): WP_Error {
-		if ( '' === $message ) {
-			$message = __( 'You can no longer save this card because another user has taken over editing. Please reload the card to see the latest changes.', 'decker' );
-		}
-
-		return new WP_Error(
-			'decker_task_locked',
-			$message,
-			array(
-				'status'     => 409,
-				'owner'      => $owner,
-				'generation' => $generation,
-			)
-		);
 	}
 
 	/**
@@ -487,30 +463,5 @@ class Decker_Task_Locks {
 		}
 
 		return self::POST_TYPE === get_post_type( $post_id );
-	}
-
-	/**
-	 * Build the public owner descriptor for a lock, or null when unavailable.
-	 *
-	 * Only the id and display name are exposed; private data such as the email
-	 * address is never included.
-	 *
-	 * @param int $owner_id The lock owner user ID.
-	 * @return array{id:int,display_name:string}|null The owner descriptor.
-	 */
-	private function build_owner_info( int $owner_id ) {
-		if ( ! $owner_id ) {
-			return null;
-		}
-
-		$owner = get_userdata( $owner_id );
-		if ( ! $owner ) {
-			return null;
-		}
-
-		return array(
-			'id'           => $owner_id,
-			'display_name' => $owner->display_name,
-		);
 	}
 }

--- a/includes/class-decker.php
+++ b/includes/class-decker.php
@@ -87,6 +87,21 @@ class Decker {
 	 * @access   private
 	 */
 	private function load_dependencies() {
+		$this->load_core_dependencies();
+		$this->load_post_type_dependencies();
+		$this->load_service_dependencies();
+		$this->load_model_dependencies();
+		$this->load_interface_dependencies();
+
+		$this->loader = new Decker_Loader();
+	}
+
+	/**
+	 * Load the loader, the AJAX layer and the task services everything else builds on.
+	 *
+	 * @access private
+	 */
+	private function load_core_dependencies() {
 
 		/**
 		 * The class responsible for orchestrating the actions and filters of the
@@ -109,25 +124,39 @@ class Decker {
 		 * User-specific "For today" relation service.
 		 */
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-task-today-manager.php';
+	}
 
-		/**
-		 * The classes responsible for defining the custom-post-types.
-		 */
+	/**
+	 * Load the custom post types, taxonomies and the controls attached to them.
+	 *
+	 * Collaborators are loaded before the post type that attaches them.
+	 *
+	 * @access private
+	 */
+	private function load_post_type_dependencies() {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-user-extended.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-actions.php';
 
-		// Term screen controls, loaded before the taxonomies that attach them.
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-term-color-field.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-board-term-fields.php';
-
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-boards.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-labels.php';
+
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-tasks.php';
+
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-event-meta-box.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-events.php';
 
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb-revisions.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb.php';
+	}
 
+	/**
+	 * Load the services that surround the content: mail, notifications, calendar and AI.
+	 *
+	 * @access private
+	 */
+	private function load_service_dependencies() {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-email-to-post.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-task-revision-manager.php';
 
@@ -145,10 +174,14 @@ class Decker {
 		 * The class responsible for protecting comments on custom post types via the REST API.
 		 */
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-rest-comment-protection.php';
+	}
 
-		/**
-		 * The class responsible for defining the MVC.
-		 */
+	/**
+	 * Load the entities and managers that make up the MVC layer.
+	 *
+	 * @access private
+	 */
+	private function load_model_dependencies() {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-decker-term-entity.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-board.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-label.php';
@@ -158,6 +191,14 @@ class Decker {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-boardmanager.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-labelmanager.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-taskmanager.php';
+	}
+
+	/**
+	 * Load the admin and public-facing entry points.
+	 *
+	 * @access private
+	 */
+	private function load_interface_dependencies() {
 
 		/**
 		 * The class responsible for network-level settings in Multisite.
@@ -182,8 +223,6 @@ class Decker {
 		 * side of the site.
 		 */
 		require_once plugin_dir_path( __DIR__ ) . 'public/class-decker-public.php';
-
-		$this->loader = new Decker_Loader();
 	}
 
 	/**

--- a/includes/class-decker.php
+++ b/includes/class-decker.php
@@ -102,6 +102,7 @@ class Decker {
 		/**
 		 * WordPress-compatible edit locking for task/card editing.
 		 */
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-task-lock-presenter.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-task-locks.php';
 
 		/**
@@ -114,11 +115,17 @@ class Decker {
 		 */
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-user-extended.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-actions.php';
+
+		// Term screen controls, loaded before the taxonomies that attach them.
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-term-color-field.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-board-term-fields.php';
+
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-boards.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-labels.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-tasks.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-events.php';
 
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb-revisions.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb.php';
 
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-email-to-post.php';

--- a/includes/custom-post-types/class-decker-board-term-fields.php
+++ b/includes/custom-post-types/class-decker-board-term-fields.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Term screen controls for the board taxonomy.
+ *
+ * Boards carry the shared colour picker plus two visibility toggles that decide
+ * whether the board shows up in the Boards and Knowledge Base sidebars.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Board_Term_Fields
+ */
+class Decker_Board_Term_Fields extends Decker_Term_Color_Field {
+
+	/**
+	 * Render the visibility toggles on the "add term" form.
+	 *
+	 * A new board is visible in both sections unless the editor says otherwise.
+	 */
+	protected function render_extra_add_fields() {
+		?>
+		<div class="form-field term-show-in-boards-wrap">
+			<label for="term-show-in-boards">
+				<input type="checkbox" name="term-show-in-boards" id="term-show-in-boards" value="1" checked>
+				<?php esc_html_e( 'Show in Boards', 'decker' ); ?>
+			</label>
+			<p class="description"><?php esc_html_e( 'Display this board in the Boards section of the sidebar', 'decker' ); ?></p>
+		</div>
+		<div class="form-field term-show-in-kb-wrap">
+			<label for="term-show-in-kb">
+				<input type="checkbox" name="term-show-in-kb" id="term-show-in-kb" value="1" checked>
+				<?php esc_html_e( 'Show in Knowledge Base', 'decker' ); ?>
+			</label>
+			<p class="description"><?php esc_html_e( 'Display this board in the Knowledge Base section of the sidebar', 'decker' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the visibility toggles on the "edit term" form.
+	 *
+	 * @param WP_Term $term The current term object.
+	 */
+	protected function render_extra_edit_fields( $term ) {
+		$term_id        = $term->term_id;
+		$show_in_boards = get_term_meta( $term_id, 'term-show-in-boards', true );
+		$show_in_kb     = get_term_meta( $term_id, 'term-show-in-kb', true );
+
+		// Default to true if not set.
+		if ( '' === $show_in_boards ) {
+			$show_in_boards = '1';
+		}
+		if ( '' === $show_in_kb ) {
+			$show_in_kb = '1';
+		}
+		?>
+		<tr class="form-field term-show-in-boards-wrap">
+			<th scope="row"><?php esc_html_e( 'Visibility', 'decker' ); ?></th>
+			<td>
+				<label for="term-show-in-boards">
+					<input type="checkbox" name="term-show-in-boards" id="term-show-in-boards" value="1" <?php checked( $show_in_boards, '1' ); ?>>
+					<?php esc_html_e( 'Show in Boards', 'decker' ); ?>
+				</label>
+				<p class="description"><?php esc_html_e( 'Display this board in the Boards section of the sidebar', 'decker' ); ?></p>
+
+				<label for="term-show-in-kb">
+					<input type="checkbox" name="term-show-in-kb" id="term-show-in-kb" value="1" <?php checked( $show_in_kb, '1' ); ?>>
+					<?php esc_html_e( 'Show in Knowledge Base', 'decker' ); ?>
+				</label>
+				<p class="description"><?php esc_html_e( 'Display this board in the Knowledge Base section of the sidebar', 'decker' ); ?></p>
+			</td>
+		</tr>
+		<?php
+	}
+
+	/**
+	 * Persist the visibility toggles.
+	 *
+	 * An unchecked box submits nothing, so absence means "hidden" rather than
+	 * "leave alone"; both keys are always written.
+	 *
+	 * @param int   $term_id The term ID.
+	 * @param array $posted  The unslashed submission.
+	 */
+	protected function save_extra_fields( $term_id, array $posted ) {
+		update_term_meta( $term_id, 'term-show-in-boards', isset( $posted['term-show-in-boards'] ) ? '1' : '0' );
+		update_term_meta( $term_id, 'term-show-in-kb', isset( $posted['term-show-in-kb'] ) ? '1' : '0' );
+	}
+}

--- a/includes/custom-post-types/class-decker-boards.php
+++ b/includes/custom-post-types/class-decker-boards.php
@@ -30,10 +30,10 @@ class Decker_Boards {
 	 */
 	private function define_hooks() {
 		add_action( 'init', array( $this, 'register_taxonomy' ) );
-		add_action( 'decker_board_add_form_fields', array( $this, 'add_color_field' ), 10, 2 );
-		add_action( 'decker_board_edit_form_fields', array( $this, 'edit_color_field' ), 10, 2 );
-		add_action( 'created_decker_board', array( $this, 'save_color_meta' ), 10, 2 );
-		add_action( 'edited_decker_board', array( $this, 'save_color_meta' ), 10, 2 );
+
+		// The colour picker and the visibility toggles own their own hooks.
+		new Decker_Board_Term_Fields( 'decker_board' );
+
 		add_action( 'delete_term', array( $this, 'decker_handle_board_deletion' ), 10, 3 );
 
 		add_filter( 'manage_edit-decker_board_columns', array( $this, 'customize_columns' ) );
@@ -84,113 +84,6 @@ class Decker_Boards {
 		);
 
 		register_taxonomy( 'decker_board', array( 'decker_task' ), $args );
-	}
-
-	/**
-	 * Add color field to add term form.
-	 */
-	public function add_color_field() {
-		wp_nonce_field( 'decker_term_action', 'decker_term_nonce' );
-		?>
-		<div class="form-field term-color-wrap">
-			<label for="term-color"><?php esc_html_e( 'Color', 'decker' ); ?></label>
-			<input name="term-color" id="term-color" type="color" value="">
-		</div>
-		<div class="form-field term-show-in-boards-wrap">
-			<label for="term-show-in-boards">
-				<input type="checkbox" name="term-show-in-boards" id="term-show-in-boards" value="1" checked>
-				<?php esc_html_e( 'Show in Boards', 'decker' ); ?>
-			</label>
-			<p class="description"><?php esc_html_e( 'Display this board in the Boards section of the sidebar', 'decker' ); ?></p>
-		</div>
-		<div class="form-field term-show-in-kb-wrap">
-			<label for="term-show-in-kb">
-				<input type="checkbox" name="term-show-in-kb" id="term-show-in-kb" value="1" checked>
-				<?php esc_html_e( 'Show in Knowledge Base', 'decker' ); ?>
-			</label>
-			<p class="description"><?php esc_html_e( 'Display this board in the Knowledge Base section of the sidebar', 'decker' ); ?></p>
-		</div>
-		<?php
-	}
-
-	/**
-	 * Add color field to edit term form.
-	 *
-	 * @param WP_Term $term The current term object.
-	 */
-	public function edit_color_field( $term ) {
-		wp_nonce_field( 'decker_term_action', 'decker_term_nonce' );
-
-		$term_id = $term->term_id;
-		$color   = get_term_meta( $term_id, 'term-color', true );
-		$show_in_boards = get_term_meta( $term_id, 'term-show-in-boards', true );
-		$show_in_kb = get_term_meta( $term_id, 'term-show-in-kb', true );
-
-		// Default to true if not set.
-		if ( '' === $show_in_boards ) {
-			$show_in_boards = '1';
-		}
-		if ( '' === $show_in_kb ) {
-			$show_in_kb = '1';
-		}
-		?>
-		<tr class="form-field term-color-wrap">
-			<th scope="row"><label for="term-color"><?php esc_html_e( 'Color', 'decker' ); ?></label></th>
-			<td>
-				<input name="term-color" id="term-color" type="color" value="<?php echo esc_attr( $color ) ? esc_attr( $color ) : ''; ?>">
-			</td>
-		</tr>
-		<tr class="form-field term-show-in-boards-wrap">
-			<th scope="row"><?php esc_html_e( 'Visibility', 'decker' ); ?></th>
-			<td>
-				<label for="term-show-in-boards">
-					<input type="checkbox" name="term-show-in-boards" id="term-show-in-boards" value="1" <?php checked( $show_in_boards, '1' ); ?>>
-					<?php esc_html_e( 'Show in Boards', 'decker' ); ?>
-				</label>
-				<p class="description"><?php esc_html_e( 'Display this board in the Boards section of the sidebar', 'decker' ); ?></p>
-				
-				<label for="term-show-in-kb">
-					<input type="checkbox" name="term-show-in-kb" id="term-show-in-kb" value="1" <?php checked( $show_in_kb, '1' ); ?>>
-					<?php esc_html_e( 'Show in Knowledge Base', 'decker' ); ?>
-				</label>
-				<p class="description"><?php esc_html_e( 'Display this board in the Knowledge Base section of the sidebar', 'decker' ); ?></p>
-			</td>
-		</tr>
-		<?php
-	}
-
-	/**
-	 * Save color metadata when a term is created or edited.
-	 *
-	 * @param int $term_id The term ID.
-	 */
-	public function save_color_meta( $term_id ) {
-		// Check if nonce is set and verified.
-		if ( isset( $_POST['decker_term_nonce'] ) ) {
-			$nonce = sanitize_text_field( wp_unslash( $_POST['decker_term_nonce'] ) );
-			if ( ! wp_verify_nonce( $nonce, 'decker_term_action' ) ) {
-				return;
-			}
-		} else {
-			return;
-		}
-
-		// Check user capabilities.
-		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			return;
-		}
-
-		if ( isset( $_POST['term-color'] ) ) {
-			$term_color = sanitize_hex_color( wp_unslash( $_POST['term-color'] ) );
-			update_term_meta( $term_id, 'term-color', $term_color );
-		}
-
-		// Save visibility settings.
-		$show_in_boards = isset( $_POST['term-show-in-boards'] ) ? '1' : '0';
-		$show_in_kb = isset( $_POST['term-show-in-kb'] ) ? '1' : '0';
-
-		update_term_meta( $term_id, 'term-show-in-boards', $show_in_boards );
-		update_term_meta( $term_id, 'term-show-in-kb', $show_in_kb );
 	}
 
 	/**

--- a/includes/custom-post-types/class-decker-event-meta-box.php
+++ b/includes/custom-post-types/class-decker-event-meta-box.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Meta boxes on the event edit screen.
+ *
+ * Everything the editor sees when opening an event: the details box with its
+ * dates, location, URL and category, and the sidebar box listing who the event
+ * is assigned to. Reading the stored meta and turning it into form controls is
+ * a separate job from registering the post type or persisting a submission,
+ * both of which stay in Decker_Events.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Event_Meta_Box
+ */
+class Decker_Event_Meta_Box {
+
+	/**
+	 * Register the meta boxes on the event edit screen.
+	 */
+	public function __construct() {
+		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+	}
+
+	/**
+	 * Add meta boxes for event details
+	 */
+	public function add_meta_boxes() {
+		add_meta_box(
+			'decker_event_details',
+			__( 'Event Details', 'decker' ),
+			array( $this, 'render_event_details_meta_box' ),
+			'decker_event',
+			'normal',
+			'high'
+		);
+
+		add_meta_box(
+			'decker_users_meta_box',
+			__( 'Assigned Users', 'decker' ),
+			array( $this, 'display_users_meta_box' ),
+			'decker_event',
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the event details meta box
+	 *
+	 * @param WP_Post $post The post object.
+	 */
+	public function render_event_details_meta_box( $post ) {
+		wp_nonce_field( 'decker_event_meta_box', 'decker_event_meta_box_nonce' );
+
+		$meta = $this->get_event_meta_box_data( $post );
+
+		$this->render_allday_field( $meta['allday'] );
+		$this->render_allday_toggle_script();
+		$this->render_date_field( 'event_start', __( 'Start:', 'decker' ), $meta['input_type'], $meta['start_for_input'], $meta['step_attr'] );
+		$this->render_date_field( 'event_end', __( 'End:', 'decker' ), $meta['input_type'], $meta['end_for_input'], $meta['step_attr'] );
+		$this->render_location_url_fields( $meta['location'], $meta['url'] );
+		$this->render_category_field( $meta['category'] );
+	}
+
+	/**
+	 * Collect and prepare the values rendered by the event details meta box.
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return array Associative array of prepared meta-box values.
+	 */
+	private function get_event_meta_box_data( $post ) {
+		$allday = get_post_meta( $post->ID, 'event_allday', true );
+		$start_utc = get_post_meta( $post->ID, 'event_start', true );
+		$end_utc = get_post_meta( $post->ID, 'event_end', true );
+		$location = get_post_meta( $post->ID, 'event_location', true );
+		$url = get_post_meta( $post->ID, 'event_url', true );
+		$category = get_post_meta( $post->ID, 'event_category', true );
+
+		$start_for_input = '';
+		$end_for_input   = '';
+		$input_type      = $allday ? 'date' : 'datetime-local';
+
+		if ( $allday ) {
+			$start_for_input = $start_utc;
+			$end_for_input   = $end_utc;
+		} elseif ( $start_utc ) {
+			// Already UTC; just format for <input type="datetime-local">.
+			$start_for_input = str_replace( ' ', 'T', $start_utc );
+			$end_for_input   = str_replace( ' ', 'T', $end_utc );
+		}
+
+				$step_attr  = $allday ? '' : ' step="60s"';          // 60s ⇒ hides seconds.
+
+		return array(
+			'allday'          => $allday,
+			'location'        => $location,
+			'url'             => $url,
+			'category'        => $category,
+			'input_type'      => $input_type,
+			'start_for_input' => $start_for_input,
+			'end_for_input'   => $end_for_input,
+			'step_attr'       => $step_attr,
+		);
+	}
+
+	/**
+	 * Render the all-day checkbox and the date error container.
+	 *
+	 * @param string $allday The stored all-day flag.
+	 */
+	private function render_allday_field( $allday ) {
+		?>
+			<p>
+	<label>
+		<input type="checkbox" name="event_allday" id="event_allday" <?php checked( $allday, '1' ); ?>>
+		<?php esc_html_e( 'All Day Event Event', 'decker' ); ?>
+	</label>
+</p>
+
+<!-- Container for error messages -->
+<div id="event_date_error" style="color: red; display: none;">
+		<?php esc_html_e( 'End Date must be after Start Date.', 'decker' ); ?>
+</div>
+		<?php
+	}
+
+	/**
+	 * Render the inline script that toggles the date/datetime input types.
+	 */
+	private function render_allday_toggle_script() {
+		?>
+<!-- Script to handle field visibility and validation -->
+<script>
+(function($) {
+	$(document).ready(function() {
+		function toggleDateType() {
+			const isAllDay = $('#event_allday').is(':checked');
+			const type = isAllDay ? 'date' : 'datetime-local';
+
+			$('#event_start, #event_end').each(function() {
+				const value = this.value;
+				const newInput = this.cloneNode();
+				newInput.type = type;
+
+				// Reassign value (convert if necessary)
+				if (type === 'date') {
+					newInput.value = value.split('T')[0];
+				} else {
+					const parts = value.split('T');
+					if (parts.length === 2) {
+						newInput.value = value;
+					} else {
+						newInput.value = value + 'T00:00';
+					}
+				}
+
+				$(this).replaceWith(newInput);
+			});
+		}
+
+		$('#event_allday').on('change', toggleDateType);
+	});
+})(jQuery);
+</script>
+		<?php
+	}
+
+	/**
+	 * Render a single start/end date input block.
+	 *
+	 * @param string $field_id   The input id/name (event_start or event_end).
+	 * @param string $label      The label text.
+	 * @param string $input_type The input type ('date' or 'datetime-local').
+	 * @param string $value      The pre-formatted input value.
+	 * @param string $step_attr  The optional step attribute fragment.
+	 */
+	private function render_date_field( $field_id, $label, $input_type, $value, $step_attr ) {
+		?>
+<p>
+	<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $label ); ?></label><br>
+	<input type="<?php echo esc_attr( $input_type ); ?>"
+		   id="<?php echo esc_attr( $field_id ); ?>"
+		   name="<?php echo esc_attr( $field_id ); ?>"
+		   value="<?php echo esc_attr( $value ); ?>"
+		   class="widefat"<?php echo esc_attr( $step_attr ); ?>>
+	<small class="description">
+		<?php esc_html_e( 'Time is stored in UTC. Adjust accordingly.', 'decker' ); ?>
+	</small>
+
+</p>
+		<?php
+	}
+
+	/**
+	 * Render the location and URL text inputs.
+	 *
+	 * @param string $location The stored location value.
+	 * @param string $url      The stored URL value.
+	 */
+	private function render_location_url_fields( $location, $url ) {
+		?>
+		<p>
+			<label for="event_location"><?php esc_html_e( 'Location:', 'decker' ); ?></label><br>
+			<input type="text" id="event_location" name="event_location"
+				value="<?php echo esc_attr( $location ); ?>" class="widefat">
+		</p>
+		<p>
+			<label for="event_url"><?php esc_html_e( 'URL:', 'decker' ); ?></label><br>
+			<input type="url" id="event_url" name="event_url"
+				value="<?php echo esc_attr( $url ); ?>" class="widefat">
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render the category select.
+	 *
+	 * @param string $category The stored category value.
+	 */
+	private function render_category_field( $category ) {
+		?>
+		<p>
+			<label for="event_category"><?php esc_html_e( 'Category:', 'decker' ); ?></label><br>
+			<select id="event_category" name="event_category">
+				<option value="bg-danger" <?php selected( $category, 'bg-danger' ); ?>><?php esc_html_e( 'Danger', 'decker' ); ?></option>
+				<option value="bg-success" <?php selected( $category, 'bg-success' ); ?>><?php esc_html_e( 'Success', 'decker' ); ?></option>
+				<option value="bg-primary" <?php selected( $category, 'bg-primary' ); ?>><?php esc_html_e( 'Primary', 'decker' ); ?></option>
+				<option value="bg-info" <?php selected( $category, 'bg-info' ); ?>><?php esc_html_e( 'Info', 'decker' ); ?></option>
+				<option value="bg-dark" <?php selected( $category, 'bg-dark' ); ?>><?php esc_html_e( 'Dark', 'decker' ); ?></option>
+				<option value="bg-warning" <?php selected( $category, 'bg-warning' ); ?>><?php esc_html_e( 'Warning', 'decker' ); ?></option>
+			</select>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Display the users meta box.
+	 *
+	 * @param WP_Post $post The current post object.
+	 */
+	public function display_users_meta_box( $post ) {
+		$users = get_users( array( 'orderby' => 'display_name' ) );
+		$assigned_users = get_post_meta( $post->ID, 'event_assigned_users', true );
+		?>
+		<div id="assigned-users" class="categorydiv">
+			<ul class="categorychecklist form-no-clear">
+				<?php foreach ( $users as $user ) { ?>
+					<li>
+						<label class="selectit">
+							<input type="checkbox" name="event_assigned_users[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php checked( is_array( $assigned_users ) && in_array( $user->ID, $assigned_users ) ); ?>>
+							<?php echo esc_html( $user->display_name ); ?>
+						</label>
+					</li>
+				<?php } ?>
+			</ul>
+		</div>
+		<?php
+	}
+}

--- a/includes/custom-post-types/class-decker-events.php
+++ b/includes/custom-post-types/class-decker-events.php
@@ -22,30 +22,6 @@ class Decker_Events {
 	}
 
 	/**
-	 * Display the users meta box.
-	 *
-	 * @param WP_Post $post The current post object.
-	 */
-	public function display_users_meta_box( $post ) {
-		$users = get_users( array( 'orderby' => 'display_name' ) );
-		$assigned_users = get_post_meta( $post->ID, 'event_assigned_users', true );
-		?>
-		<div id="assigned-users" class="categorydiv">
-			<ul class="categorychecklist form-no-clear">
-				<?php foreach ( $users as $user ) { ?>
-					<li>
-						<label class="selectit">
-							<input type="checkbox" name="event_assigned_users[]" value="<?php echo esc_attr( $user->ID ); ?>" <?php checked( is_array( $assigned_users ) && in_array( $user->ID, $assigned_users ) ); ?>>
-							<?php echo esc_html( $user->display_name ); ?>
-						</label>
-					</li>
-				<?php } ?>
-			</ul>
-		</div>
-		<?php
-	}
-
-	/**
 	 * Hide visibility options for decker_event post type.
 	 */
 	public function hide_visibility_options() {
@@ -66,7 +42,8 @@ class Decker_Events {
 		add_action( 'init', array( $this, 'register_post_type' ) );
 		add_filter( 'rest_pre_dispatch', array( $this, 'restrict_rest_access' ), 10, 3 );
 
-		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
+		// The edit-screen meta boxes own their own hook.
+		new Decker_Event_Meta_Box();
 		add_action( 'save_post_decker_event', array( $this, 'save_event_meta' ), 10, 3 );
 
 		add_filter( 'use_block_editor_for_post_type', array( $this, 'force_classic_editor' ), 10, 2 );
@@ -329,218 +306,6 @@ class Decker_Events {
 			$end = gmdate( 'Y-m-d H:i:s', strtotime( $start ) + HOUR_IN_SECONDS );
 			update_post_meta( $post->ID, 'event_end', $end );
 		}
-	}
-
-	/**
-	 * Add meta boxes for event details
-	 */
-	public function add_meta_boxes() {
-		add_meta_box(
-			'decker_event_details',
-			__( 'Event Details', 'decker' ),
-			array( $this, 'render_event_details_meta_box' ),
-			'decker_event',
-			'normal',
-			'high'
-		);
-
-		add_meta_box(
-			'decker_users_meta_box',
-			__( 'Assigned Users', 'decker' ),
-			array( $this, 'display_users_meta_box' ),
-			'decker_event',
-			'side',
-			'default'
-		);
-	}
-
-	/**
-	 * Render the event details meta box
-	 *
-	 * @param WP_Post $post The post object.
-	 */
-	public function render_event_details_meta_box( $post ) {
-		wp_nonce_field( 'decker_event_meta_box', 'decker_event_meta_box_nonce' );
-
-		$meta = $this->get_event_meta_box_data( $post );
-
-		$this->render_allday_field( $meta['allday'] );
-		$this->render_allday_toggle_script();
-		$this->render_date_field( 'event_start', __( 'Start:', 'decker' ), $meta['input_type'], $meta['start_for_input'], $meta['step_attr'] );
-		$this->render_date_field( 'event_end', __( 'End:', 'decker' ), $meta['input_type'], $meta['end_for_input'], $meta['step_attr'] );
-		$this->render_location_url_fields( $meta['location'], $meta['url'] );
-		$this->render_category_field( $meta['category'] );
-	}
-
-	/**
-	 * Collect and prepare the values rendered by the event details meta box.
-	 *
-	 * @param WP_Post $post The post object.
-	 * @return array Associative array of prepared meta-box values.
-	 */
-	private function get_event_meta_box_data( $post ) {
-		$allday = get_post_meta( $post->ID, 'event_allday', true );
-		$start_utc = get_post_meta( $post->ID, 'event_start', true );
-		$end_utc = get_post_meta( $post->ID, 'event_end', true );
-		$location = get_post_meta( $post->ID, 'event_location', true );
-		$url = get_post_meta( $post->ID, 'event_url', true );
-		$category = get_post_meta( $post->ID, 'event_category', true );
-
-		$start_for_input = '';
-		$end_for_input   = '';
-		$input_type      = $allday ? 'date' : 'datetime-local';
-
-		if ( $allday ) {
-			$start_for_input = $start_utc;
-			$end_for_input   = $end_utc;
-		} elseif ( $start_utc ) {
-			// Already UTC; just format for <input type="datetime-local">.
-			$start_for_input = str_replace( ' ', 'T', $start_utc );
-			$end_for_input   = str_replace( ' ', 'T', $end_utc );
-		}
-
-				$step_attr  = $allday ? '' : ' step="60s"';          // 60s ⇒ hides seconds.
-
-		return array(
-			'allday'          => $allday,
-			'location'        => $location,
-			'url'             => $url,
-			'category'        => $category,
-			'input_type'      => $input_type,
-			'start_for_input' => $start_for_input,
-			'end_for_input'   => $end_for_input,
-			'step_attr'       => $step_attr,
-		);
-	}
-
-	/**
-	 * Render the all-day checkbox and the date error container.
-	 *
-	 * @param string $allday The stored all-day flag.
-	 */
-	private function render_allday_field( $allday ) {
-		?>
-			<p>
-	<label>
-		<input type="checkbox" name="event_allday" id="event_allday" <?php checked( $allday, '1' ); ?>>
-		<?php esc_html_e( 'All Day Event Event', 'decker' ); ?>
-	</label>
-</p>
-
-<!-- Container for error messages -->
-<div id="event_date_error" style="color: red; display: none;">
-		<?php esc_html_e( 'End Date must be after Start Date.', 'decker' ); ?>
-</div>
-		<?php
-	}
-
-	/**
-	 * Render the inline script that toggles the date/datetime input types.
-	 */
-	private function render_allday_toggle_script() {
-		?>
-<!-- Script to handle field visibility and validation -->
-<script>
-(function($) {
-	$(document).ready(function() {
-		function toggleDateType() {
-			const isAllDay = $('#event_allday').is(':checked');
-			const type = isAllDay ? 'date' : 'datetime-local';
-
-			$('#event_start, #event_end').each(function() {
-				const value = this.value;
-				const newInput = this.cloneNode();
-				newInput.type = type;
-
-				// Reassign value (convert if necessary)
-				if (type === 'date') {
-					newInput.value = value.split('T')[0];
-				} else {
-					const parts = value.split('T');
-					if (parts.length === 2) {
-						newInput.value = value;
-					} else {
-						newInput.value = value + 'T00:00';
-					}
-				}
-
-				$(this).replaceWith(newInput);
-			});
-		}
-
-		$('#event_allday').on('change', toggleDateType);
-	});
-})(jQuery);
-</script>
-		<?php
-	}
-
-	/**
-	 * Render a single start/end date input block.
-	 *
-	 * @param string $field_id   The input id/name (event_start or event_end).
-	 * @param string $label      The label text.
-	 * @param string $input_type The input type ('date' or 'datetime-local').
-	 * @param string $value      The pre-formatted input value.
-	 * @param string $step_attr  The optional step attribute fragment.
-	 */
-	private function render_date_field( $field_id, $label, $input_type, $value, $step_attr ) {
-		?>
-<p>
-	<label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $label ); ?></label><br>
-	<input type="<?php echo esc_attr( $input_type ); ?>"
-		   id="<?php echo esc_attr( $field_id ); ?>"
-		   name="<?php echo esc_attr( $field_id ); ?>"
-		   value="<?php echo esc_attr( $value ); ?>"
-		   class="widefat"<?php echo esc_attr( $step_attr ); ?>>
-	<small class="description">
-		<?php esc_html_e( 'Time is stored in UTC. Adjust accordingly.', 'decker' ); ?>
-	</small>
-
-</p>
-		<?php
-	}
-
-	/**
-	 * Render the location and URL text inputs.
-	 *
-	 * @param string $location The stored location value.
-	 * @param string $url      The stored URL value.
-	 */
-	private function render_location_url_fields( $location, $url ) {
-		?>
-		<p>
-			<label for="event_location"><?php esc_html_e( 'Location:', 'decker' ); ?></label><br>
-			<input type="text" id="event_location" name="event_location"
-				value="<?php echo esc_attr( $location ); ?>" class="widefat">
-		</p>
-		<p>
-			<label for="event_url"><?php esc_html_e( 'URL:', 'decker' ); ?></label><br>
-			<input type="url" id="event_url" name="event_url"
-				value="<?php echo esc_attr( $url ); ?>" class="widefat">
-		</p>
-		<?php
-	}
-
-	/**
-	 * Render the category select.
-	 *
-	 * @param string $category The stored category value.
-	 */
-	private function render_category_field( $category ) {
-		?>
-		<p>
-			<label for="event_category"><?php esc_html_e( 'Category:', 'decker' ); ?></label><br>
-			<select id="event_category" name="event_category">
-				<option value="bg-danger" <?php selected( $category, 'bg-danger' ); ?>><?php esc_html_e( 'Danger', 'decker' ); ?></option>
-				<option value="bg-success" <?php selected( $category, 'bg-success' ); ?>><?php esc_html_e( 'Success', 'decker' ); ?></option>
-				<option value="bg-primary" <?php selected( $category, 'bg-primary' ); ?>><?php esc_html_e( 'Primary', 'decker' ); ?></option>
-				<option value="bg-info" <?php selected( $category, 'bg-info' ); ?>><?php esc_html_e( 'Info', 'decker' ); ?></option>
-				<option value="bg-dark" <?php selected( $category, 'bg-dark' ); ?>><?php esc_html_e( 'Dark', 'decker' ); ?></option>
-				<option value="bg-warning" <?php selected( $category, 'bg-warning' ); ?>><?php esc_html_e( 'Warning', 'decker' ); ?></option>
-			</select>
-		</p>
-		<?php
 	}
 
 	/**
@@ -834,4 +599,3 @@ class Decker_Events {
 if ( class_exists( 'Decker_Events' ) ) {
 	new Decker_Events();
 }
-

--- a/includes/custom-post-types/class-decker-kb-revisions.php
+++ b/includes/custom-post-types/class-decker-kb-revisions.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Revision history for Knowledge Base articles.
+ *
+ * Records who last touched an article and points at the WordPress revision
+ * screen for it. This is reporting about an article's history rather than part
+ * of managing the article itself, so it lives apart from Decker_Kb.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Kb_Revisions
+ */
+class Decker_Kb_Revisions {
+
+	/**
+	 * Register the hooks that keep the last editor up to date.
+	 */
+	public function __construct() {
+		add_action( 'save_post_decker_kb', array( $this, 'track_last_editor' ), 10, 2 );
+	}
+
+	/**
+	 * Track the last user who edited a KB article.
+	 *
+	 * Stores the current user ID as post meta so the UI can display
+	 * the last editor instead of the original post author.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function track_last_editor( $post_id, $post ) {
+		// Skip autosaves and revisions.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id && current_user_can( 'edit_post', $post_id ) ) {
+			update_post_meta( $post_id, '_last_editor', $current_user_id );
+		}
+	}
+
+	/**
+	 * Get the last editor user ID for a KB article.
+	 *
+	 * Falls back to the post author if no last editor is recorded.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int User ID of the last editor.
+	 */
+	public static function get_last_editor( $post_id ) {
+		$last_editor = get_post_meta( $post_id, '_last_editor', true );
+		if ( $last_editor ) {
+			return intval( $last_editor );
+		}
+		$post = get_post( $post_id );
+		return $post ? intval( $post->post_author ) : 0;
+	}
+
+	/**
+	 * Get the latest revision ID for a KB article.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int Revision ID or 0 when no revisions exist.
+	 */
+	public static function get_latest_revision_id( $post_id ) {
+		$revisions = wp_get_post_revisions(
+			$post_id,
+			array(
+				'posts_per_page' => 1,
+			)
+		);
+
+		if ( empty( $revisions ) ) {
+			return 0;
+		}
+
+		return self::extract_latest_revision_id_from_list( $revisions );
+	}
+
+	/**
+	 * Get the WordPress revision history URL for a KB article.
+	 *
+	 * The WordPress revision screen includes the diff UI and restore actions.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string Admin URL or empty string if no revision exists.
+	 */
+	public static function get_revision_admin_url( $post_id ) {
+		return self::build_revision_admin_url(
+			self::get_latest_revision_id( $post_id )
+		);
+	}
+
+	/**
+	 * Extract the latest revision ID from a revision list.
+	 *
+	 * @param array $revisions Revision list.
+	 * @return int
+	 */
+	private static function extract_latest_revision_id_from_list( $revisions ) {
+		if ( empty( $revisions ) ) {
+			return 0;
+		}
+
+		$revision_list = array_values( $revisions );
+
+		return isset( $revision_list[0]->ID ) ? intval( $revision_list[0]->ID ) : 0;
+	}
+
+	/**
+	 * Build a revision admin URL from a revision ID.
+	 *
+	 * Public so a caller that already looked the revision up can reuse it
+	 * instead of paying for a second query through get_revision_admin_url().
+	 *
+	 * @param int $revision_id Revision ID.
+	 * @return string
+	 */
+	public static function build_revision_admin_url( $revision_id ) {
+		if ( ! $revision_id ) {
+			return '';
+		}
+
+		return admin_url(
+			sprintf(
+				'revision.php?revision=%d',
+				intval( $revision_id )
+			)
+		);
+	}
+}

--- a/includes/custom-post-types/class-decker-kb.php
+++ b/includes/custom-post-types/class-decker-kb.php
@@ -34,8 +34,8 @@ class Decker_Kb {
 		// REST API endpoints.
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
 
-		// Track last editor.
-		add_action( 'save_post_decker_kb', array( $this, 'track_last_editor' ), 10, 2 );
+		// Revision reporting owns its own hooks.
+		new Decker_Kb_Revisions();
 	}
 
 	/**
@@ -80,117 +80,6 @@ class Decker_Kb {
 	 */
 	public function check_permissions() {
 		return current_user_can( 'edit_posts' );
-	}
-
-	/**
-	 * Track the last user who edited a KB article.
-	 *
-	 * Stores the current user ID as post meta so the UI can display
-	 * the last editor instead of the original post author.
-	 *
-	 * @param int     $post_id Post ID.
-	 * @param WP_Post $post    Post object.
-	 */
-	public function track_last_editor( $post_id, $post ) {
-		// Skip autosaves and revisions.
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-		if ( wp_is_post_revision( $post_id ) ) {
-			return;
-		}
-
-		$current_user_id = get_current_user_id();
-		if ( $current_user_id && current_user_can( 'edit_post', $post_id ) ) {
-			update_post_meta( $post_id, '_last_editor', $current_user_id );
-		}
-	}
-
-	/**
-	 * Get the last editor user ID for a KB article.
-	 *
-	 * Falls back to the post author if no last editor is recorded.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return int User ID of the last editor.
-	 */
-	public static function get_last_editor( $post_id ) {
-		$last_editor = get_post_meta( $post_id, '_last_editor', true );
-		if ( $last_editor ) {
-			return intval( $last_editor );
-		}
-		$post = get_post( $post_id );
-		return $post ? intval( $post->post_author ) : 0;
-	}
-
-	/**
-	 * Get the latest revision ID for a KB article.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return int Revision ID or 0 when no revisions exist.
-	 */
-	public static function get_latest_revision_id( $post_id ) {
-		$revisions = wp_get_post_revisions(
-			$post_id,
-			array(
-				'posts_per_page' => 1,
-			)
-		);
-
-		if ( empty( $revisions ) ) {
-			return 0;
-		}
-
-		return self::extract_latest_revision_id_from_list( $revisions );
-	}
-
-	/**
-	 * Get the WordPress revision history URL for a KB article.
-	 *
-	 * The WordPress revision screen includes the diff UI and restore actions.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return string Admin URL or empty string if no revision exists.
-	 */
-	public static function get_revision_admin_url( $post_id ) {
-		return self::build_revision_admin_url(
-			self::get_latest_revision_id( $post_id )
-		);
-	}
-
-	/**
-	 * Extract the latest revision ID from a revision list.
-	 *
-	 * @param array $revisions Revision list.
-	 * @return int
-	 */
-	private static function extract_latest_revision_id_from_list( $revisions ) {
-		if ( empty( $revisions ) ) {
-			return 0;
-		}
-
-		$revision_list = array_values( $revisions );
-
-		return isset( $revision_list[0]->ID ) ? intval( $revision_list[0]->ID ) : 0;
-	}
-
-	/**
-	 * Build a revision admin URL.
-	 *
-	 * @param int $revision_id Revision ID.
-	 * @return string
-	 */
-	private static function build_revision_admin_url( $revision_id ) {
-		if ( ! $revision_id ) {
-			return '';
-		}
-
-		return admin_url(
-			sprintf(
-				'revision.php?revision=%d',
-				intval( $revision_id )
-			)
-		);
 	}
 
 	/**
@@ -645,9 +534,9 @@ class Decker_Kb {
 		$board_terms = wp_get_object_terms( $article_id, 'decker_board', array( 'fields' => 'ids' ) );
 		$board_id = ! empty( $board_terms ) ? $board_terms[0] : 0;
 		$author_id = intval( $post->post_author );
-		$last_editor_id = self::get_last_editor( $article_id );
-		$latest_revision_id = self::get_latest_revision_id( $article_id );
-		$history_url        = self::build_revision_admin_url( $latest_revision_id );
+		$last_editor_id = Decker_Kb_Revisions::get_last_editor( $article_id );
+		$latest_revision_id = Decker_Kb_Revisions::get_latest_revision_id( $article_id );
+		$history_url        = Decker_Kb_Revisions::build_revision_admin_url( $latest_revision_id );
 		$revision_count     = count( wp_get_post_revisions( $article_id ) );
 
 		return new WP_REST_Response(

--- a/includes/custom-post-types/class-decker-labels.php
+++ b/includes/custom-post-types/class-decker-labels.php
@@ -31,10 +31,9 @@ class Decker_Labels {
 	private function define_hooks() {
 		add_action( 'init', array( $this, 'register_taxonomy' ) );
 		add_action( 'init', array( $this, 'register_meta' ) );
-		add_action( 'decker_label_add_form_fields', array( $this, 'add_color_field' ), 10, 2 );
-		add_action( 'decker_label_edit_form_fields', array( $this, 'edit_color_field' ), 10, 2 );
-		add_action( 'created_decker_label', array( $this, 'save_color_meta' ), 10, 2 );
-		add_action( 'edited_decker_label', array( $this, 'save_color_meta' ), 10, 2 );
+
+		// The colour picker owns its own hooks.
+		new Decker_Term_Color_Field( 'decker_label' );
 
 		add_action( 'admin_head', array( $this, 'hide_description' ) );
 		add_filter( 'manage_edit-decker_label_columns', array( $this, 'customize_columns' ) );
@@ -83,67 +82,6 @@ class Decker_Labels {
 		);
 
 		register_taxonomy( 'decker_label', array( 'decker_task' ), $args );
-	}
-
-	/**
-	 * Add color field in the add new term form.
-	 */
-	public function add_color_field() {
-		wp_nonce_field( 'decker_term_action', 'decker_term_nonce' );
-		?>
-		<div class="form-field term-color-wrap">
-			<label for="term-color"><?php esc_html_e( 'Color', 'decker' ); ?></label>
-			<input name="term-color" id="term-color" type="color" value="">
-		</div>
-		<?php
-	}
-
-	/**
-	 * Add color field in the edit term form.
-	 *
-	 * @param WP_Term $term The current term object.
-	 */
-	public function edit_color_field( $term ) {
-		wp_nonce_field( 'decker_term_action', 'decker_term_nonce' );
-
-		$term_id = $term->term_id;
-		$color   = get_term_meta( $term_id, 'term-color', true );
-		?>
-		<tr class="form-field term-color-wrap">
-			<th scope="row"><label for="term-color"><?php esc_html_e( 'Color', 'decker' ); ?></label></th>
-			<td>
-				<input name="term-color" id="term-color" type="color" value="<?php echo esc_attr( $color ) ? esc_attr( $color ) : ''; ?>">
-			</td>
-		</tr>
-		<?php
-	}
-
-	/**
-	 * Save the color meta when a term is created or edited.
-	 *
-	 * @param int $term_id The term ID.
-	 */
-	public function save_color_meta( $term_id ) {
-
-		// Check if nonce is set and verified.
-		if ( isset( $_POST['decker_term_nonce'] ) ) {
-			$nonce = sanitize_text_field( wp_unslash( $_POST['decker_term_nonce'] ) );
-			if ( ! wp_verify_nonce( $nonce, 'decker_term_action' ) ) {
-				return;
-			}
-		} else {
-			return;
-		}
-
-		// Check user capabilities.
-		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			return;
-		}
-
-		if ( isset( $_POST['term-color'] ) ) {
-			$term_color = sanitize_hex_color( wp_unslash( $_POST['term-color'] ) );
-			update_term_meta( $term_id, 'term-color', $term_color );
-		}
 	}
 
 	/**

--- a/includes/custom-post-types/class-decker-term-color-field.php
+++ b/includes/custom-post-types/class-decker-term-color-field.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Colour picker shown on the term screens of a Decker taxonomy.
+ *
+ * Boards and labels both offer the same colour control, so the markup, the
+ * nonce and the save guards live here once. A taxonomy that needs extra
+ * controls alongside the colour subclasses this and fills in the hooks below,
+ * which keeps a single nonce field and a single save guard per form.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Term_Color_Field
+ */
+class Decker_Term_Color_Field {
+
+	/**
+	 * Taxonomy this instance is attached to.
+	 *
+	 * @access protected
+	 * @var    string
+	 */
+	protected $taxonomy;
+
+	/**
+	 * Attach the colour field to a taxonomy's term screens.
+	 *
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public function __construct( $taxonomy ) {
+		$this->taxonomy = $taxonomy;
+
+		add_action( "{$taxonomy}_add_form_fields", array( $this, 'render_add_field' ), 10, 2 );
+		add_action( "{$taxonomy}_edit_form_fields", array( $this, 'render_edit_field' ), 10, 2 );
+		add_action( "created_{$taxonomy}", array( $this, 'save' ), 10, 2 );
+		add_action( "edited_{$taxonomy}", array( $this, 'save' ), 10, 2 );
+	}
+
+	/**
+	 * Render the colour field on the "add term" form.
+	 */
+	public function render_add_field() {
+		wp_nonce_field( 'decker_term_action', 'decker_term_nonce' );
+		?>
+		<div class="form-field term-color-wrap">
+			<label for="term-color"><?php esc_html_e( 'Color', 'decker' ); ?></label>
+			<input name="term-color" id="term-color" type="color" value="">
+		</div>
+		<?php
+		$this->render_extra_add_fields();
+	}
+
+	/**
+	 * Render the colour field on the "edit term" form.
+	 *
+	 * @param WP_Term $term The current term object.
+	 */
+	public function render_edit_field( $term ) {
+		wp_nonce_field( 'decker_term_action', 'decker_term_nonce' );
+
+		$color = get_term_meta( $term->term_id, 'term-color', true );
+		?>
+		<tr class="form-field term-color-wrap">
+			<th scope="row"><label for="term-color"><?php esc_html_e( 'Color', 'decker' ); ?></label></th>
+			<td>
+				<input name="term-color" id="term-color" type="color" value="<?php echo esc_attr( $color ) ? esc_attr( $color ) : ''; ?>">
+			</td>
+		</tr>
+		<?php
+		$this->render_extra_edit_fields( $term );
+	}
+
+	/**
+	 * Persist the colour when a term is created or edited.
+	 *
+	 * @param int $term_id The term ID.
+	 */
+	public function save( $term_id ) {
+		// Check if nonce is set and verified.
+		if ( isset( $_POST['decker_term_nonce'] ) ) {
+			$nonce = sanitize_text_field( wp_unslash( $_POST['decker_term_nonce'] ) );
+			if ( ! wp_verify_nonce( $nonce, 'decker_term_action' ) ) {
+				return;
+			}
+		} else {
+			return;
+		}
+
+		// Check user capabilities.
+		if ( ! current_user_can( 'edit_term', $term_id ) ) {
+			return;
+		}
+
+		if ( isset( $_POST['term-color'] ) ) {
+			$term_color = sanitize_hex_color( wp_unslash( $_POST['term-color'] ) );
+			update_term_meta( $term_id, 'term-color', $term_color );
+		}
+
+		// Hand the submission to the subclass so it never has to re-check the
+		// nonce or reach into the superglobal itself.
+		$this->save_extra_fields( $term_id, wp_unslash( $_POST ) );
+	}
+
+	/**
+	 * Render any additional controls on the "add term" form.
+	 *
+	 * Subclasses override this; the colour field alone needs nothing extra.
+	 */
+	protected function render_extra_add_fields() {
+	}
+
+	/**
+	 * Render any additional controls on the "edit term" form.
+	 *
+	 * @param WP_Term $term The current term object.
+	 */
+	protected function render_extra_edit_fields( $term ) {
+	}
+
+	/**
+	 * Persist any additional controls.
+	 *
+	 * Only called once the nonce and capability checks have passed.
+	 *
+	 * @param int   $term_id The term ID.
+	 * @param array $posted  The unslashed submission.
+	 */
+	protected function save_extra_fields( $term_id, array $posted ) {
+	}
+}

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -519,15 +519,15 @@ msgstr ""
 msgid "You are not authorized to access this resource."
 msgstr ""
 
+msgid "You can no longer save this card because another user has taken over editing. Please reload the card to see the latest changes."
+msgstr ""
+
 #. translators: %s is the display name of the user currently editing the card.
 #, php-format
 msgid "This card is currently locked by %s."
 msgstr ""
 
 msgid "Invalid task."
-msgstr ""
-
-msgid "You can no longer save this card because another user has taken over editing. Please reload the card to see the latest changes."
 msgstr ""
 
 msgid "You are not allowed to edit this card."
@@ -599,6 +599,21 @@ msgstr ""
 msgid "Terms in the Actions taxonomy cannot be more than two levels deep."
 msgstr ""
 
+msgid "Show in Boards"
+msgstr ""
+
+msgid "Display this board in the Boards section of the sidebar"
+msgstr ""
+
+msgid "Show in Knowledge Base"
+msgstr ""
+
+msgid "Display this board in the Knowledge Base section of the sidebar"
+msgstr ""
+
+msgid "Visibility"
+msgstr ""
+
 msgctxt "taxonomy general name"
 msgid "Boards"
 msgstr ""
@@ -629,65 +644,6 @@ msgid "Boards"
 msgstr ""
 
 msgid "Color"
-msgstr ""
-
-msgid "Show in Boards"
-msgstr ""
-
-msgid "Display this board in the Boards section of the sidebar"
-msgstr ""
-
-msgid "Show in Knowledge Base"
-msgstr ""
-
-msgid "Display this board in the Knowledge Base section of the sidebar"
-msgstr ""
-
-msgid "Visibility"
-msgstr ""
-
-msgctxt "post type general name"
-msgid "Events"
-msgstr ""
-
-msgctxt "post type singular name"
-msgid "Event"
-msgstr ""
-
-msgctxt "admin menu"
-msgid "Events"
-msgstr ""
-
-msgctxt "add new on admin bar"
-msgid "Event"
-msgstr ""
-
-msgctxt "event"
-msgid "Add New"
-msgstr ""
-
-msgid "Add New Event"
-msgstr ""
-
-msgid "New Event"
-msgstr ""
-
-msgid "Edit Event"
-msgstr ""
-
-msgid "View Event"
-msgstr ""
-
-msgid "Search Events"
-msgstr ""
-
-msgid "No events found."
-msgstr ""
-
-msgid "No events found in Trash."
-msgstr ""
-
-msgid "You do not have permission to access this resource."
 msgstr ""
 
 msgid "Event Details"
@@ -733,6 +689,50 @@ msgid "Info"
 msgstr ""
 
 msgid "Dark"
+msgstr ""
+
+msgctxt "post type general name"
+msgid "Events"
+msgstr ""
+
+msgctxt "post type singular name"
+msgid "Event"
+msgstr ""
+
+msgctxt "admin menu"
+msgid "Events"
+msgstr ""
+
+msgctxt "add new on admin bar"
+msgid "Event"
+msgstr ""
+
+msgctxt "event"
+msgid "Add New"
+msgstr ""
+
+msgid "Add New Event"
+msgstr ""
+
+msgid "New Event"
+msgstr ""
+
+msgid "Edit Event"
+msgstr ""
+
+msgid "View Event"
+msgstr ""
+
+msgid "Search Events"
+msgstr ""
+
+msgid "No events found."
+msgstr ""
+
+msgid "No events found in Trash."
+msgstr ""
+
+msgid "You do not have permission to access this resource."
 msgstr ""
 
 msgid "All Day Event"

--- a/public/app-knowledge-base.php
+++ b/public/app-knowledge-base.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'decker_get_kb_people_html' ) ) {
 	 */
 	function decker_get_kb_people_html( $post_id ) {
 		$author_id      = intval( get_post_field( 'post_author', $post_id ) );
-		$last_editor_id = Decker_Kb::get_last_editor( $post_id );
+		$last_editor_id = Decker_Kb_Revisions::get_last_editor( $post_id );
 		$author_name    = get_the_author_meta( 'display_name', $author_id );
 		$last_editor_name = $last_editor_id ? get_the_author_meta( 'display_name', $last_editor_id ) : '';
 		$author_label   = __( 'Author', 'decker' ) . ': ' . $author_name;
@@ -269,7 +269,7 @@ die();
 													echo '<td title="' . esc_attr( $exact_date ) . '">' . esc_html( $relative_date ) . '</td>';
 
 													// Actions.
-													$history_url  = Decker_Kb::get_revision_admin_url( $article->ID );
+													$history_url  = Decker_Kb_Revisions::get_revision_admin_url( $article->ID );
 													echo '<td class="text-end">';
 													// View button.
 													echo '<button type="button" class="btn btn-sm btn-secondary me-2 view-article-btn" ' .
@@ -468,8 +468,8 @@ die();
 																												 title="<?php echo esc_attr__( 'Comments', 'decker' ); ?>">
 																												 <i class="ri-chat-1-line"></i>
 																												 </button>
-																												 <?php if ( Decker_Kb::get_revision_admin_url( $article->ID ) ) : ?>
-																												 <a href="<?php echo esc_url( Decker_Kb::get_revision_admin_url( $article->ID ) ); ?>" class="btn btn-outline-dark" title="<?php echo esc_attr__( 'History', 'decker' ); ?>" target="_blank" rel="noopener noreferrer">
+																												 <?php if ( Decker_Kb_Revisions::get_revision_admin_url( $article->ID ) ) : ?>
+																												 <a href="<?php echo esc_url( Decker_Kb_Revisions::get_revision_admin_url( $article->ID ) ); ?>" class="btn btn-outline-dark" title="<?php echo esc_attr__( 'History', 'decker' ); ?>" target="_blank" rel="noopener noreferrer">
 																												 <i class="ri-history-line"></i>
 																												 </a>
 																												 <?php endif; ?>
@@ -513,8 +513,8 @@ die();
 																														 data-labels='<?php echo esc_attr( $article_data_json['labels'] ); ?>'
 																														 data-board='<?php echo esc_attr( $article_data_json['board'] ); ?>'>
 																														 <i class="ri-chat-1-line me-1"></i><?php esc_html_e( 'Comments', 'decker' ); ?></button></li>
-																														 <?php if ( Decker_Kb::get_revision_admin_url( $article->ID ) ) : ?>
-																														 <li><a class="dropdown-item" href="<?php echo esc_url( Decker_Kb::get_revision_admin_url( $article->ID ) ); ?>" target="_blank" rel="noopener noreferrer"><i class="ri-history-line me-1"></i><?php esc_html_e( 'History', 'decker' ); ?></a></li>
+																														 <?php if ( Decker_Kb_Revisions::get_revision_admin_url( $article->ID ) ) : ?>
+																														 <li><a class="dropdown-item" href="<?php echo esc_url( Decker_Kb_Revisions::get_revision_admin_url( $article->ID ) ); ?>" target="_blank" rel="noopener noreferrer"><i class="ri-history-line me-1"></i><?php esc_html_e( 'History', 'decker' ); ?></a></li>
 																														 <?php endif; ?>
 																														 <li><button class="dropdown-item kb-edit-btn" data-article-id="<?php echo esc_attr( $article->ID ); ?>"><i class="ri-pencil-line me-1"></i><?php esc_html_e( 'Edit', 'decker' ); ?></button></li>
 																														 <li><button class="dropdown-item add-child-btn" data-parent-id="<?php echo esc_attr( $article->ID ); ?>" data-bs-toggle="modal" data-bs-target="#kb-modal"><i class="ri-add-line me-1"></i><?php esc_html_e( 'Add Child', 'decker' ); ?></button></li>

--- a/tests/includes/class-wp-unittest-factory-for-decker-board.php
+++ b/tests/includes/class-wp-unittest-factory-for-decker-board.php
@@ -80,7 +80,8 @@ class WP_UnitTest_Factory_For_Decker_Board extends WP_UnitTest_Factory_For_Term 
 			unset( $_POST['term-show-in-kb'] );
 		}
 
-		( new Decker_Boards() )->save_color_meta( $term_id );
+		// Fire the hook WordPress fires, so the fields' owner stays an implementation detail.
+		do_action( 'edited_decker_board', $term_id, 0 );
 
 		return $term_id;
 	}
@@ -146,7 +147,8 @@ class WP_UnitTest_Factory_For_Decker_Board extends WP_UnitTest_Factory_For_Term 
 			}
 		}
 
-		( new Decker_Boards() )->save_color_meta( $term_id );
+		// Fire the hook WordPress fires, so the fields' owner stays an implementation detail.
+		do_action( 'edited_decker_board', $term_id, 0 );
 
 		return $term_id;
 	}

--- a/tests/includes/class-wp-unittest-factory-for-decker-label.php
+++ b/tests/includes/class-wp-unittest-factory-for-decker-label.php
@@ -60,7 +60,8 @@ class WP_UnitTest_Factory_For_Decker_Label extends WP_UnitTest_Factory_For_Term 
 		// Save color meta through Decker_Labels logic
 		$_POST['decker_term_nonce'] = wp_create_nonce( 'decker_term_action' );
 		$_POST['term-color']        = $args['color'];
-		( new Decker_Labels() )->save_color_meta( $term_id );
+		// Fire the hook WordPress fires, so the fields' owner stays an implementation detail.
+		do_action( 'edited_decker_label', $term_id, 0 );
 
 		return $term_id;
 	}
@@ -105,7 +106,8 @@ class WP_UnitTest_Factory_For_Decker_Label extends WP_UnitTest_Factory_For_Term 
 		if ( isset( $fields['color'] ) ) {
 			$_POST['decker_term_nonce'] = wp_create_nonce( 'decker_term_action' );
 			$_POST['term-color']        = $fields['color'];
-			( new Decker_Labels() )->save_color_meta( $term_id );
+			// Fire the hook WordPress fires, so the fields' owner stays an implementation detail.
+		do_action( 'edited_decker_label', $term_id, 0 );
 		}
 	}
 }

--- a/tests/unit/includes/custom-post-types/DeckerEventsAndKBEdgeCasesTest.php
+++ b/tests/unit/includes/custom-post-types/DeckerEventsAndKBEdgeCasesTest.php
@@ -250,7 +250,7 @@ class KnowledgeBaseEdgeCasesTest extends WP_Test_REST_TestCase {
 		);
 		delete_post_meta( $post_id, '_last_editor' );
 
-		$this->assertSame( $this->admin_id, Decker_KB::get_last_editor( $post_id ) );
+		$this->assertSame( $this->admin_id, Decker_Kb_Revisions::get_last_editor( $post_id ) );
 	}
 
 	/**

--- a/tests/unit/includes/custom-post-types/DeckerEventsMetaBoxTest.php
+++ b/tests/unit/includes/custom-post-types/DeckerEventsMetaBoxTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Characterization tests for Decker_Events::render_event_details_meta_box().
+ * Characterization tests for Decker_Event_Meta_Box::render_event_details_meta_box().
  *
  * These pin the exact rendered markup (including the pre-existing
  * `step=&quot;60s&quot;` quirk) so the markup-splitting refactor stays
@@ -57,7 +57,7 @@ class DeckerEventsMetaBoxTest extends Decker_Test_Base {
 	 */
 	private function render( $post_id ) {
 		ob_start();
-		( new Decker_Events() )->render_event_details_meta_box( get_post( $post_id ) );
+		( new Decker_Event_Meta_Box() )->render_event_details_meta_box( get_post( $post_id ) );
 		return ob_get_clean();
 	}
 

--- a/tests/unit/includes/custom-post-types/DeckerKnowledgeBaseTest.php
+++ b/tests/unit/includes/custom-post-types/DeckerKnowledgeBaseTest.php
@@ -255,7 +255,7 @@ class DeckerKnowledgeBaseTest extends WP_Test_REST_TestCase {
 			)
 		);
 
-		$last_editor_id = Decker_Kb::get_last_editor( $post_id );
+		$last_editor_id = Decker_Kb_Revisions::get_last_editor( $post_id );
 		$this->assertEquals( $this->editor, $last_editor_id );
 	}
 
@@ -274,7 +274,7 @@ class DeckerKnowledgeBaseTest extends WP_Test_REST_TestCase {
 		// Remove the meta to simulate an article created before this feature.
 		delete_post_meta( $post_id, '_last_editor' );
 
-		$last_editor_id = Decker_Kb::get_last_editor( $post_id );
+		$last_editor_id = Decker_Kb_Revisions::get_last_editor( $post_id );
 		$this->assertEquals( $this->administrator, $last_editor_id );
 	}
 
@@ -297,8 +297,8 @@ class DeckerKnowledgeBaseTest extends WP_Test_REST_TestCase {
 			)
 		);
 
-		$revision_id  = Decker_Kb::get_latest_revision_id( $post_id );
-		$revision_url = Decker_Kb::get_revision_admin_url( $post_id );
+		$revision_id  = Decker_Kb_Revisions::get_latest_revision_id( $post_id );
+		$revision_url = Decker_Kb_Revisions::get_revision_admin_url( $post_id );
 
 		$this->assertGreaterThan( 0, $revision_id );
 		$this->assertStringContainsString(

--- a/tests/unit/includes/custom-post-types/DeckerTermFieldsTest.php
+++ b/tests/unit/includes/custom-post-types/DeckerTermFieldsTest.php
@@ -268,17 +268,29 @@ class DeckerTermFieldsTest extends Decker_Test_Base {
 
 	/**
 	 * A user without the capability cannot change term meta.
+	 *
+	 * The nonce is minted after switching user on purpose. WordPress nonces are
+	 * tied to the current user and session, so a nonce created as the
+	 * administrator would fail verification here and the save would be refused
+	 * before the capability check ever ran — the test would then pass even with
+	 * that check deleted.
 	 */
 	public function test_save_requires_the_edit_term_capability() {
 		$term = $this->make_term( 'decker_board', 'Capability guarded' );
 
-		$nonce = wp_create_nonce( 'decker_term_action' );
-
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber );
 
 		$_POST = array(
-			'decker_term_nonce' => $nonce,
+			'decker_term_nonce' => wp_create_nonce( 'decker_term_action' ),
 			'term-color'        => '#654321',
+		);
+
+		// Guard the guard: the nonce must be the valid one for this user, so
+		// that the capability check is what refuses the save.
+		$this->assertNotFalse(
+			wp_verify_nonce( $_POST['decker_term_nonce'], 'decker_term_action' ),
+			'The nonce must be valid for the subscriber, or this test proves nothing.'
 		);
 
 		do_action( 'edited_decker_board', $term->term_id, 0 );

--- a/tests/unit/includes/custom-post-types/DeckerTermFieldsTest.php
+++ b/tests/unit/includes/custom-post-types/DeckerTermFieldsTest.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Characterization tests for the term fields on the board and label screens.
+ *
+ * These drive the WordPress hooks rather than the classes behind them, so the
+ * fields can be moved to a different owner without the tests noticing. What is
+ * pinned is the rendered markup, the saved meta, and the guards around saving.
+ *
+ * @package Decker
+ */
+
+class DeckerTermFieldsTest extends Decker_Test_Base {
+
+	/**
+	 * Administrator able to manage terms.
+	 *
+	 * @var int
+	 */
+	private $administrator;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		do_action( 'init' );
+
+		$this->administrator = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->administrator );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		$_POST = array();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Capture the markup a term form hook produces.
+	 *
+	 * @param string $hook Action name.
+	 * @param mixed  $arg  Optional argument passed to the hook.
+	 * @return string Rendered markup.
+	 */
+	private function render( $hook, $arg = null ) {
+		ob_start();
+
+		if ( null === $arg ) {
+			do_action( $hook );
+		} else {
+			do_action( $hook, $arg );
+		}
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Create a term and return it.
+	 *
+	 * @param string $taxonomy Taxonomy slug.
+	 * @param string $name     Term name.
+	 * @return WP_Term
+	 */
+	private function make_term( $taxonomy, $name ) {
+		$ids = wp_insert_term( $name, $taxonomy );
+		$this->assertNotWPError( $ids );
+
+		return get_term( $ids['term_id'], $taxonomy );
+	}
+
+	/**
+	 * The board add form offers a colour picker and both visibility toggles.
+	 */
+	public function test_board_add_form_fields() {
+		$html = $this->render( 'decker_board_add_form_fields' );
+
+		$this->assertStringContainsString( 'name="term-color"', $html );
+		$this->assertStringContainsString( 'type="color"', $html );
+		$this->assertStringContainsString( 'name="term-show-in-boards"', $html );
+		$this->assertStringContainsString( 'name="term-show-in-kb"', $html );
+
+		// Both toggles default to on when creating a board.
+		$this->assertSame( 2, substr_count( $html, 'value="1" checked' ) );
+	}
+
+	/**
+	 * The label add form offers a colour picker and no visibility toggles.
+	 */
+	public function test_label_add_form_fields() {
+		$html = $this->render( 'decker_label_add_form_fields' );
+
+		$this->assertStringContainsString( 'name="term-color"', $html );
+		$this->assertStringContainsString( 'type="color"', $html );
+		$this->assertStringNotContainsString( 'term-show-in-boards', $html );
+		$this->assertStringNotContainsString( 'term-show-in-kb', $html );
+	}
+
+	/**
+	 * Exactly one nonce field is emitted per form.
+	 *
+	 * Splitting the fields across several hook callbacks would be an easy way to
+	 * end up printing the nonce twice, so this is pinned explicitly.
+	 *
+	 * @dataProvider term_form_hook_provider
+	 *
+	 * @param string $hook       Action name.
+	 * @param bool   $needs_term Whether the hook receives a term.
+	 * @param string $taxonomy   Taxonomy slug.
+	 */
+	public function test_exactly_one_nonce_field_per_form( $hook, $needs_term, $taxonomy ) {
+		$arg = $needs_term ? $this->make_term( $taxonomy, 'Nonce fixture' ) : null;
+
+		$html = $this->render( $hook, $arg );
+
+		$this->assertSame(
+			1,
+			substr_count( $html, 'name="decker_term_nonce"' ),
+			"Hook '{$hook}' should print the nonce field exactly once."
+		);
+	}
+
+	/**
+	 * Every term form hook, and whether it receives a term.
+	 *
+	 * @return array<string, array{0:string,1:bool,2:string}>
+	 */
+	public function term_form_hook_provider() {
+		return array(
+			'board add'  => array( 'decker_board_add_form_fields', false, 'decker_board' ),
+			'board edit' => array( 'decker_board_edit_form_fields', true, 'decker_board' ),
+			'label add'  => array( 'decker_label_add_form_fields', false, 'decker_label' ),
+			'label edit' => array( 'decker_label_edit_form_fields', true, 'decker_label' ),
+		);
+	}
+
+	/**
+	 * The board edit form reflects the stored colour and visibility meta.
+	 */
+	public function test_board_edit_form_reflects_stored_meta() {
+		$term = $this->make_term( 'decker_board', 'Stored board' );
+
+		update_term_meta( $term->term_id, 'term-color', '#abcdef' );
+		update_term_meta( $term->term_id, 'term-show-in-boards', '0' );
+		update_term_meta( $term->term_id, 'term-show-in-kb', '1' );
+
+		$html = $this->render( 'decker_board_edit_form_fields', $term );
+
+		$this->assertStringContainsString( 'value="#abcdef"', $html );
+
+		// Only the knowledge base toggle should come back checked.
+		$this->assertSame( 1, substr_count( $html, "checked='checked'" ) );
+		$this->assertMatchesRegularExpression(
+			'/term-show-in-kb"[^>]*checked=/',
+			$html,
+			'The knowledge base toggle should be checked.'
+		);
+	}
+
+	/**
+	 * Visibility toggles default to on for a board that has no stored preference.
+	 */
+	public function test_board_edit_form_defaults_visibility_to_on() {
+		$term = $this->make_term( 'decker_board', 'Fresh board' );
+
+		$html = $this->render( 'decker_board_edit_form_fields', $term );
+
+		$this->assertSame( 2, substr_count( $html, "checked='checked'" ) );
+	}
+
+	/**
+	 * The label edit form shows the colour and nothing about visibility.
+	 */
+	public function test_label_edit_form_shows_colour_only() {
+		$term = $this->make_term( 'decker_label', 'Stored label' );
+		update_term_meta( $term->term_id, 'term-color', '#123456' );
+
+		$html = $this->render( 'decker_label_edit_form_fields', $term );
+
+		$this->assertStringContainsString( 'value="#123456"', $html );
+		$this->assertStringNotContainsString( 'term-show-in-boards', $html );
+	}
+
+	/**
+	 * Saving a board stores the sanitized colour and both visibility flags.
+	 */
+	public function test_saving_a_board_stores_colour_and_visibility() {
+		$term = $this->make_term( 'decker_board', 'Saved board' );
+
+		$_POST = array(
+			'decker_term_nonce'    => wp_create_nonce( 'decker_term_action' ),
+			'term-color'           => '#00ff00',
+			'term-show-in-boards'  => '1',
+			// term-show-in-kb intentionally absent: an unchecked box sends nothing.
+		);
+
+		do_action( 'edited_decker_board', $term->term_id, 0 );
+
+		$this->assertSame( '#00ff00', get_term_meta( $term->term_id, 'term-color', true ) );
+		$this->assertSame( '1', get_term_meta( $term->term_id, 'term-show-in-boards', true ) );
+		$this->assertSame( '0', get_term_meta( $term->term_id, 'term-show-in-kb', true ) );
+	}
+
+	/**
+	 * Saving a label stores the colour.
+	 */
+	public function test_saving_a_label_stores_colour() {
+		$term = $this->make_term( 'decker_label', 'Saved label' );
+
+		$_POST = array(
+			'decker_term_nonce' => wp_create_nonce( 'decker_term_action' ),
+			'term-color'        => '#ff0000',
+		);
+
+		do_action( 'edited_decker_label', $term->term_id, 0 );
+
+		$this->assertSame( '#ff0000', get_term_meta( $term->term_id, 'term-color', true ) );
+	}
+
+	/**
+	 * A colour that is not a valid hex value is rejected by sanitization.
+	 */
+	public function test_invalid_colour_is_not_stored() {
+		$term = $this->make_term( 'decker_board', 'Bad colour' );
+
+		$_POST = array(
+			'decker_term_nonce' => wp_create_nonce( 'decker_term_action' ),
+			'term-color'        => 'javascript:alert(1)',
+		);
+
+		do_action( 'edited_decker_board', $term->term_id, 0 );
+
+		$this->assertEmpty( get_term_meta( $term->term_id, 'term-color', true ) );
+	}
+
+	/**
+	 * Nothing is saved without a valid nonce.
+	 *
+	 * @dataProvider missing_nonce_provider
+	 *
+	 * @param array $post Payload standing in for $_POST.
+	 */
+	public function test_save_requires_a_valid_nonce( $post ) {
+		$term = $this->make_term( 'decker_board', 'Nonce guarded' );
+
+		$_POST = array_merge( array( 'term-color' => '#123123' ), $post );
+
+		do_action( 'edited_decker_board', $term->term_id, 0 );
+
+		$this->assertEmpty( get_term_meta( $term->term_id, 'term-color', true ) );
+		$this->assertEmpty( get_term_meta( $term->term_id, 'term-show-in-boards', true ) );
+	}
+
+	/**
+	 * Payloads that must not pass the nonce guard.
+	 *
+	 * @return array<string, array{0:array}>
+	 */
+	public function missing_nonce_provider() {
+		return array(
+			'no nonce at all' => array( array() ),
+			'wrong nonce'     => array( array( 'decker_term_nonce' => 'not-a-real-nonce' ) ),
+		);
+	}
+
+	/**
+	 * A user without the capability cannot change term meta.
+	 */
+	public function test_save_requires_the_edit_term_capability() {
+		$term = $this->make_term( 'decker_board', 'Capability guarded' );
+
+		$nonce = wp_create_nonce( 'decker_term_action' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$_POST = array(
+			'decker_term_nonce' => $nonce,
+			'term-color'        => '#654321',
+		);
+
+		do_action( 'edited_decker_board', $term->term_id, 0 );
+
+		$this->assertEmpty( get_term_meta( $term->term_id, 'term-color', true ) );
+	}
+}


### PR DESCRIPTION
Second pass on the PHPMD `codesize` alerts, following #290. Takes the count from **25 to 20**.

Runtime behaviour is unchanged. The class surface is not: thirteen public methods now live on a different class. See *Compatibility* below.

Round one cleared the method-level warnings. Everything left is class-level, so this round works the only way those move: giving a cohesive responsibility its own class rather than shuffling methods inside the one that outgrew them.

## What moved

| Class | Warning cleared | New owner |
|---|---|---|
| `Decker_Boards` | TooManyPublicMethods (11 → 8) | `Decker_Term_Color_Field` + `Decker_Board_Term_Fields` |
| `Decker_Labels` | TooManyPublicMethods (11 → 8) | `Decker_Term_Color_Field` |
| `Decker_Kb` | TooManyPublicMethods (11 → 7) | `Decker_Kb_Revisions` |
| `Decker_Task_Locks` | ExcessiveClassComplexity (52 → 47) | `Decker_Task_Lock_Presenter` |
| `Decker_Events` | TooManyMethods (27 → 18) | `Decker_Event_Meta_Box` |

**5 cleared, 0 added**, verified by diffing the full `phpmd` run before and after, keyed on file + rule.

## The one that also removes duplication

Boards and labels both offered the same colour picker, duplicated field for field. That markup, its nonce and its save guards now live once in `Decker_Term_Color_Field`.

Boards needs two visibility toggles alongside the colour. Rather than registering separate callbacks for them, `Decker_Board_Term_Fields` subclasses the colour field and fills in three hooks. That matters for a specific reason: `wp_nonce_field()` is emitted inside the render methods, so splitting the fields across two hook callbacks would have printed the nonce twice and duplicated the save guard. A test pins this explicitly — each form must emit exactly one nonce field.

## A warning this refactor created, and then removed

Adding the `require_once` lines for five new classes pushed `Decker::load_dependencies()` to exactly 100 lines. `ExcessiveMethodLength` reports **at** the threshold, not above it, so the refactor produced a warning of its own. Caught by the before/after diff, not by reading the code.

The loader now delegates to one method per layer — core services, post types, surrounding services, models, entry points — which is the shape its own comments already described.

## Tests

15 added for the term screens, which had none: rendered controls for both taxonomies, the one-nonce rule above, visibility defaults, and that saving is refused without a valid nonce or the `edit_term` capability.

They drive the WordPress hooks rather than the classes behind them, so the fields could change owner without the tests noticing — which is the point, and is why they were written before the move. The board and label test factories called `save_color_meta()` directly; they now fire the same hook WordPress fires, for the same reason.

**One of them was a false positive**, caught in review. `test_save_requires_the_edit_term_capability()` minted the nonce while still the administrator and only then switched to the subscriber. Nonces are bound to the current user and session, so verification failed and the save was refused one guard too early — the test passed even with the capability check deleted outright, which a mutation run confirmed. The nonce is now created after the switch, and the test asserts it verifies before acting, so the refusal it observes can only come from the capability check. Deleting that check now fails the test.

## Compatibility

Raised in review, and the original description was wrong to call this "no behaviour changes" without qualification. Nothing observable differs at runtime, but these thirteen public methods moved:

| Was | Is now |
| --- | --- |
| `Decker_Boards::add_color_field()` / `edit_color_field()` / `save_color_meta()` | `Decker_Board_Term_Fields` |
| `Decker_Labels::add_color_field()` / `edit_color_field()` / `save_color_meta()` | `Decker_Term_Color_Field` |
| `Decker_Kb::track_last_editor()` / `get_last_editor()` / `get_latest_revision_id()` / `get_revision_admin_url()` | `Decker_Kb_Revisions` |
| `Decker_Events::add_meta_boxes()` / `display_users_meta_box()` / `render_event_details_meta_box()` | `Decker_Event_Meta_Box` |

Ten of the thirteen are WordPress hook callbacks, public only because WordPress has to be able to call them. Three are static getters on `Decker_Kb`.

**Deliberately shipped without shims.** Delegating methods would return `Decker_Kb` to 11 public methods, and `Decker_Boards` and `Decker_Labels` to 11 each — re-triggering three of the five warnings this PR clears, so the rule would have to be suppressed to keep them. Given the plugin is at version `0.0.0`, none of these methods is documented as an interface, and the documented extension surface is the hooks (12 actions, 3 filters) plus `Decker_Tasks::create_or_update_task()` — none of which this PR touches — the reorganisation is treated as internal and recorded rather than shimmed.

`docs/development.md` now states which surface is stable and carries the table above, including the entry for #290's `Decker_Public_Assets`.

**The sharpest consequence, which is worth calling out:** unhooking one of these by name now fails *silently*, not fatally.

```php
// No longer matches anything; the field still renders, with no error.
remove_action( 'decker_board_add_form_fields', array( $boards, 'add_color_field' ) );
```

A fatal from a moved static getter is loud and easy to trace; this one is not. It is documented for that reason.

## Notes for the reviewer

- `Decker_Kb_Revisions::build_revision_admin_url()` is public rather than private so the REST handler can reuse a revision ID it already looked up, instead of paying for a second query through `get_revision_admin_url()`.
- Three `Decker_Kb::` statics moved, so their call sites in `public/app-knowledge-base.php` and the tests are updated. No compatibility shims were left behind — a shim would have kept the method count where it was.
- `Decker_Events` still exceeds the complexity and public-method thresholds. The remaining excess is the meta-saving code, which has 19 call sites in a test file named for it; that is its own PR.

## Out of scope

The 20 remaining are all class-level. In rough order of how much they need to shed: `Decker_Tasks` (5 warnings, and a genuine rewrite), `Decker_Admin_Settings` (3), `Decker_Notification_Handler` (2), `Task` (2), then single warnings on `Decker_Calendar`, `TaskManager`, `Decker_Kb`, `Decker_Email_To_Post`, `Decker_Demo_Data` and `Decker_Events`. `create_or_update_task`'s 15-parameter signature is still the riskiest single edit available and is still deferred.

## Verification

- **PHPMD**: 20 results on the PR ref, confirmed by the code-scanning API, against 25 on `main`.
- **CI**: all checks green, including `lint_and_test` (lint, Plugin Check, unit and E2E).
- **Full local suite**: 884 tests, 15 failures, every one inside the set that already fails on `main` — the pre-existing suite-interaction failures in Calendar, DemoData, Sidebar and TaskManager. Zero new.

That last comparison earned its keep: the first full-suite run flagged a genuine regression this PR had introduced. One call site spelled the class `Decker_KB` rather than `Decker_Kb`, and since PHP resolves class names case-insensitively it worked fine — but the sweep that redirected callers was case-sensitive and skipped it. Fixed in `629afdd`, then rechecked case-insensitively across the tree.
