### PR TITLE
Reduce PHPMD codesize alerts from 20 to 14

### DIFF
--- a/admin/class-decker-admin-settings-fields.php
+++ b/admin/class-decker-admin-settings-fields.php
@@ -1,0 +1,361 @@
+<?php
+/**
+ * Renders the fields of the Decker settings screen.
+ *
+ * Each field of the screen is drawn by one private method here. WordPress
+ * reaches them through the single public render() dispatcher, which
+ * add_settings_field() hands the field id as an argument, so adding a field
+ * does not add to this class's public surface.
+ *
+ * @package    Decker
+ * @subpackage Decker/admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Admin_Settings_Fields
+ */
+class Decker_Admin_Settings_Fields {
+
+	/**
+	 * Render one settings field.
+	 *
+	 * Registered as the callback of every add_settings_field() call, which
+	 * passes the field id in $args.
+	 *
+	 * @param array $args Field arguments; 'field' holds the field id.
+	 */
+	public function render( $args ) {
+		$method = ( isset( $args['field'] ) ? $args['field'] : '' ) . '_render';
+
+		if ( method_exists( $this, $method ) ) {
+			$this->$method();
+		}
+	}
+
+	/**
+	 * Settings Section Callback.
+	 *
+	 * Outputs a description for the settings section.
+	 */
+	public function settings_section_callback() {
+		echo '<p>' . esc_html__( 'Configure the Decker plugin settings.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * AI Settings Section Callback.
+	 *
+	 * Outputs a description for the AI settings section.
+	 *
+	 * @return void
+	 */
+	public function ai_settings_section_callback() {
+		echo '<p>' . esc_html__( 'Configure how Decker improves task descriptions with AI. Browser-based Gemini Nano keeps the text in the browser, while the Gemini API sends the prompt to Google through your WordPress server using the saved API key.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Shared Key Field
+	 *
+	 * Outputs the HTML for the shared_key field, generating it only if it does not exist or does not meet the criteria.
+	 */
+	private function shared_key_render() {
+		$options = get_option( 'decker_settings', array() );
+
+		// Generate a new shared key (UUID) only if it does not exist or does not meet criteria.
+		if ( empty( $options['shared_key'] ) ) {
+			$options['shared_key'] = wp_generate_uuid4();
+			// Save the newly generated UUID back to the options.
+			update_option( 'decker_settings', $options );
+		}
+
+		$value = sanitize_text_field( $options['shared_key'] );
+		echo '<input type="text" name="decker_settings[shared_key]" pattern=".{8,}" value="' . esc_attr( $value ) . '" class="regular-text" pattern="" title="The key must be at least 8 characters long and include letters, numbers, and symbols." required>';
+		echo '<p class="description">' . esc_html__( 'Provide the Bearer token in the Authorization header for the email-to-post endpoint. Example request:', 'decker' ) . '</p>';
+		echo '<pre style="background: #f5f5f5; padding: 10px; border: 1px solid #ccc; border-radius: 4px;">';
+		echo 'POST ' . esc_url( get_site_url() ) . '/wp-json/decker/v1/email-to-post';
+		echo "\nHeader: Authorization: Bearer YOUR_SHARED_KEY";
+		echo '</pre>';
+	}
+
+	/**
+	 * Render Allow Email Notifications Field.
+	 *
+	 * Outputs the HTML for the allow_email_notifications field.
+	 */
+	private function allow_email_notifications_render() {
+		$options = get_option( 'decker_settings', array() );
+		$checked = isset( $options['allow_email_notifications'] ) && '1' === $options['allow_email_notifications'];
+
+		echo '<label>';
+		echo '<input type="checkbox" name="decker_settings[allow_email_notifications]" value="1" ' . checked( $checked, true, false ) . '>';
+		echo esc_html__( 'Enable email notifications for all plugin events.', 'decker' );
+		echo '</label>';
+		echo '<p class="description">' . esc_html__( 'This setting allows users to manage email notifications in their profile. By default, all notifications are enabled.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Collaborative Editing Field.
+	 *
+	 * Outputs the HTML for the collaborative_editing field.
+	 */
+	private function collaborative_editing_render() {
+		$options = get_option( 'decker_settings', array() );
+		$checked = isset( $options['collaborative_editing'] ) && '1' === $options['collaborative_editing'];
+
+		echo '<label>';
+		echo '<input type="checkbox" name="decker_settings[collaborative_editing]" value="1" ' . checked( $checked, true, false ) . '>';
+		echo esc_html__( 'Enable real-time collaborative editing for tasks.', 'decker' );
+		echo '</label>';
+		echo '<p class="description">' . esc_html__( 'When enabled, multiple users can edit the same task simultaneously with real-time synchronization using WebRTC.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Board Status Indicators Field.
+	 *
+	 * Outputs a browser-local preference for the board status indicators.
+	 */
+	private function sidebar_board_status_render() {
+		echo '<label for="sidebar-board-status-check">';
+		echo '<input type="checkbox" id="sidebar-board-status-check" value="1" checked data-decker-persistent aria-describedby="sidebar-board-status-description"> ';
+		echo esc_html__( 'Show board status indicators', 'decker' );
+		echo '</label>';
+		echo '<p class="description" id="sidebar-board-status-description">' . esc_html__( 'This preference is saved only in this browser.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render AI Enabled Field.
+	 *
+	 * Outputs the HTML for the ai_enabled field.
+	 *
+	 * @return void
+	 */
+	private function ai_enabled_render() {
+		$options = get_option( 'decker_settings', array() );
+		$checked = isset( $options['ai_enabled'] ) && '1' === $options['ai_enabled'];
+
+		echo '<label>';
+		echo '<input type="checkbox" name="decker_settings[ai_enabled]" value="1" ' . checked( $checked, true, false ) . '>';
+		echo esc_html__( 'Enable AI improvements for task descriptions.', 'decker' );
+		echo '</label>';
+		echo '<p class="description">' . esc_html__( 'When enabled, users can improve task descriptions with either Gemini Nano in supported browsers or the Gemini API through the server.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render AI Provider Field.
+	 *
+	 * Outputs the HTML for the ai_provider field.
+	 *
+	 * @return void
+	 */
+	private function ai_provider_render() {
+		$options  = get_option( 'decker_settings', array() );
+		$provider = Decker_AI_Manager::get_selected_provider( $options );
+		$choices  = array(
+			Decker_AI_Manager::PROVIDER_BROWSER_GEMINI_NANO => __(
+				'Gemini Nano (browser-based)',
+				'decker'
+			),
+			Decker_AI_Manager::PROVIDER_GEMINI_API          => __(
+				'Gemini API (server-side)',
+				'decker'
+			),
+		);
+
+		foreach ( $choices as $value => $label ) {
+			echo '<p><label>';
+			echo '<input type="radio" name="decker_settings[ai_provider]" value="' . esc_attr( $value ) . '" ' . checked( $provider, $value, false ) . '>';
+			echo esc_html( $label );
+			echo '</label></p>';
+		}
+
+		echo '<p class="description">' . esc_html__( 'Choose whether AI improvements run in the browser with Gemini Nano or through the Gemini API on the server.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render AI API Key Field.
+	 *
+	 * Outputs the HTML for the ai_api_key field.
+	 *
+	 * @return void
+	 */
+	private function ai_api_key_render() {
+		$options        = get_option( 'decker_settings', array() );
+		$has_saved_key  = ! empty( $options['ai_api_key'] );
+		$placeholder    = $has_saved_key ? '••••••••••••••••' : '';
+		$description    = $has_saved_key
+			? __( 'A Gemini API key is already stored. Leave this field empty to keep the current key.', 'decker' )
+			: __( 'Paste a Gemini API key to enable server-side Gemini requests. The saved key is never shown again after saving.', 'decker' );
+
+		echo '<input type="password" name="decker_settings[ai_api_key]" class="regular-text" value="" autocomplete="off" placeholder="' . esc_attr( $placeholder ) . '">';
+		echo '<p class="description">' . esc_html( $description ) . '</p>';
+	}
+
+	/**
+	 * Render AI Model Field.
+	 *
+	 * Outputs the HTML for the ai_model field.
+	 *
+	 * @return void
+	 */
+	private function ai_model_render() {
+		$options = get_option( 'decker_settings', array() );
+		$value   = Decker_AI_Manager::get_model( $options );
+
+		echo '<input type="text" name="decker_settings[ai_model]" class="regular-text" value="' . esc_attr( $value ) . '" placeholder="' . esc_attr( Decker_AI_Manager::DEFAULT_GEMINI_MODEL ) . '">';
+		echo '<p class="description">' . esc_html__( 'Optional Gemini model name for server-side requests. Leave the default unless you need a different compatible text-generation model.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render AI Prompt Field.
+	 *
+	 * Outputs the HTML for the ai_prompt field.
+	 *
+	 * @return void
+	 */
+	private function ai_prompt_render() {
+		$options = get_option( 'decker_settings', array() );
+		$value   = isset( $options['ai_prompt'] ) && '' !== $options['ai_prompt']
+			? sanitize_textarea_field( $options['ai_prompt'] )
+			: Decker::get_default_ai_prompt_template();
+
+		echo '<textarea name="decker_settings[ai_prompt]" class="large-text code" rows="12">' . esc_textarea( $value ) . '</textarea>';
+		echo '<p class="description">' . esc_html__( 'Customize the base prompt used for AI improvements. For smaller nano-class models, it usually works better to write this base prompt in English and let the model translate the final result into the WordPress language. Available placeholders: {{mode_instruction}}, {{task_context}}, {{content_html}}, {{language_instruction}}, {{response_format}}.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Signaling Server Field.
+	 *
+	 * Outputs the HTML for the signaling_server field.
+	 */
+	private function signaling_server_render() {
+		$options = get_option( 'decker_settings', array() );
+		$value   = isset( $options['signaling_server'] ) ? sanitize_text_field( $options['signaling_server'] ) : 'wss://signaling.yjs.dev';
+
+		echo '<input type="url" name="decker_settings[signaling_server]" class="regular-text" value="' . esc_attr( $value ) . '" placeholder="wss://signaling.yjs.dev">';
+		echo '<p class="description">' . esc_html__( 'WebRTC signaling server URL for collaborative editing. Leave empty to use the default public server (wss://signaling.yjs.dev).', 'decker' ) . '</p>';
+		echo '<p class="description"><strong>' . esc_html__( 'Public servers:', 'decker' ) . '</strong></p>';
+		echo '<ul class="description" style="list-style: disc; margin-left: 20px;">';
+		echo '<li><code>wss://signaling.yjs.dev</code> ' . esc_html__( '(Default - Global)', 'decker' ) . '</li>';
+		echo '<li><code>wss://y-webrtc-signaling-eu.herokuapp.com</code> ' . esc_html__( '(Europe)', 'decker' ) . '</li>';
+		echo '<li><code>wss://y-webrtc-signaling-us.herokuapp.com</code> ' . esc_html__( '(United States)', 'decker' ) . '</li>';
+		echo '</ul>';
+	}
+
+	/**
+	 * Render User Profile Field.
+	 *
+	 * Outputs the HTML for the minimum_user_profile field, displaying only roles with edit permissions.
+	 */
+	private function minimum_user_profile_render() {
+		// Get saved plugin options.
+		$options       = get_option( 'decker_settings', array() );
+
+		// Default to 'editor' if no user profile is selected.
+		$selected_role = isset( $options['minimum_user_profile'] ) && ! empty( $options['minimum_user_profile'] ) ? $options['minimum_user_profile'] : 'editor';
+
+		// Retrieve all registered roles in WordPress.
+		$roles = wp_roles()->roles;
+
+		// Filter roles to include only those with 'edit_posts' capability.
+		$editable_roles = array_filter(
+			$roles,
+			function ( $role ) {
+				return isset( $role['capabilities']['edit_posts'] ) && $role['capabilities']['edit_posts'];
+			}
+		);
+
+		// Render the select dropdown for user profiles.
+		echo '<select name="decker_settings[minimum_user_profile]" id="minimum_user_profile">';
+		foreach ( $editable_roles as $role_value => $role_data ) {
+			echo '<option value="' . esc_attr( $role_value ) . '" ' . selected( $selected_role, $role_value, false ) . '>' . esc_html( $role_data['name'] ) . '</option>';
+		}
+		echo '</select>';
+
+		// Add a description below the dropdown.
+		echo '<p class="description">' . esc_html__( 'Select the minimum user profile that can use Decker.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Alert Message Field.
+	 *
+	 * Outputs the HTML for the alert_message field.
+	 */
+	private function alert_message_render() {
+		$options = get_option( 'decker_settings', array() );
+		$value   = isset( $options['alert_message'] ) ? wp_kses_post( $options['alert_message'] ) : '';
+		echo '<textarea name="decker_settings[alert_message]" class="large-text" rows="5">' . esc_textarea( $value ) . '</textarea>';
+		echo '<p class="description">' . esc_html__( 'Enter the alert message to display as a banner. Supports HTML. Leave empty to hide.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Alert Color Field.
+	 *
+	 * Outputs the HTML for the alert_color field.
+	 */
+	private function alert_color_render() {
+		$options = get_option( 'decker_settings', array() );
+		$color   = isset( $options['alert_color'] ) ? $options['alert_color'] : 'info';
+
+		$colors = array(
+			'success' => 'Success',
+			'danger'  => 'Danger',
+			'warning' => 'Warning',
+			'info'    => 'Info',
+		);
+
+		foreach ( $colors as $value => $label ) {
+			echo '<label style="margin-right: 15px;">';
+			echo '<input type="radio" name="decker_settings[alert_color]" value="' . esc_attr( $value ) . '" ' . checked( $color, $value, false ) . '>';
+			echo esc_html( $label );
+			echo '</label>';
+		}
+		echo '<p class="description">' . esc_html__( 'Select the color for the alert message.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Ignored Users Field.
+	 *
+	 * Outputs the HTML for the ignored_users field.
+	 */
+	private function ignored_users_render() {
+		$options = get_option( 'decker_settings', array() );
+		$value = isset( $options['ignored_users'] ) ? sanitize_text_field( $options['ignored_users'] ) : '';
+		echo '<input type="text" name="decker_settings[ignored_users]" class="regular-text" value="' . esc_attr( $value ) . '" pattern="^[0-9]+(,[0-9]+)*$" title="' . esc_attr__( 'Please enter comma-separated user IDs (numbers only)', 'decker' ) . '">';
+		echo '<p class="description">' . esc_html__( 'Enter comma-separated user IDs to ignore from Decker functionality.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Task Editor Type Field.
+	 *
+	 * Outputs the HTML for the task_editor_type field.
+	 */
+	private function task_editor_type_render() {
+		$options     = get_option( 'decker_settings', array() );
+		$editor_type = isset( $options['task_editor_type'] ) ? $options['task_editor_type'] : 'quill';
+		$editors     = array(
+			'classic' => __( 'Classic Editor', 'decker' ),
+			'quill'   => __( 'Quill Editor', 'decker' ),
+		);
+
+		foreach ( $editors as $value => $label ) {
+			echo '<label style="margin-right: 15px;">';
+			echo '<input type="radio" name="decker_settings[task_editor_type]" value="' . esc_attr( $value ) . '" ' . checked( $editor_type, $value, false ) . '>';
+			echo esc_html( $label );
+			echo '</label>';
+		}
+
+		echo '<p class="description">' . esc_html__( 'Choose which editor to use for task descriptions. Collaborative editing always uses Quill.', 'decker' ) . '</p>';
+	}
+
+	/**
+	 * Render Clear All Data Button.
+	 *
+	 * Outputs the HTML for the clear_all_data_button field.
+	 */
+	private function clear_all_data_button_render() {
+		wp_nonce_field( 'decker_clear_all_data_action', 'decker_clear_all_data_nonce', true, true );
+		echo '<input type="submit" name="decker_clear_all_data" class="button button-secondary" style="background-color: red; color: white;" value="' . esc_attr__( 'Clear All Data', 'decker' ) . '" onclick="return confirm(\'' . esc_js( __( 'Are you sure you want to delete all Decker records? This action cannot be undone.', 'decker' ) ) . '\');">';
+		echo '<p class="description">' . esc_html__( 'Click the button to delete all Decker labels, tasks, and boards.', 'decker' ) . '</p>';
+	}
+}

--- a/admin/class-decker-admin-settings-validator.php
+++ b/admin/class-decker-admin-settings-validator.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Validates the Decker settings before they are stored.
+ *
+ * Owns one private method per field plus the shared checkbox helper; the
+ * public validate() applies them all in the order the settings screen lists
+ * the fields.
+ *
+ * @package    Decker
+ * @subpackage Decker/admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Admin_Settings_Validator
+ */
+class Decker_Admin_Settings_Validator {
+
+	/**
+	 * Validate a settings submission.
+	 *
+	 * @param mixed $input          The raw submission.
+	 * @param array $current_values The currently stored settings option.
+	 * @return array The validated fields.
+	 */
+	public function validate( $input, array $current_values ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$input = $this->strip_legacy_openai_fields( $input );
+
+		// Validate shared key.
+		$input['shared_key'] = $this->validate_shared_key( $input );
+
+		// Validate allow email notifications.
+		$input['allow_email_notifications'] = $this->sanitize_checkbox( $input, 'allow_email_notifications' );
+
+		// Validate collaborative editing.
+		$input['collaborative_editing'] = $this->sanitize_checkbox( $input, 'collaborative_editing' );
+
+		// Validate AI settings.
+		$input['ai_enabled']  = $this->sanitize_checkbox( $input, 'ai_enabled' );
+		$input['ai_provider'] = Decker_AI_Manager::get_selected_provider( $input );
+		$input['ai_api_key']  = $this->validate_ai_api_key( $input, $current_values );
+		$input['ai_model']    = $this->validate_ai_model( $input );
+		$input['ai_prompt']   = $this->validate_ai_prompt( $input );
+
+		// Validate signaling server.
+		$input['signaling_server'] = $this->validate_signaling_server( $input );
+
+		// Validate alert color.
+		$input['alert_color'] = $this->validate_alert_color( $input );
+
+		// Validate user profile.
+		$input['minimum_user_profile'] = $this->validate_minimum_user_profile( $input );
+
+		// Validate task editor type. Quill stays the default during the transition period.
+		$valid_editors = array( 'classic', 'quill' );
+		if ( ! isset( $input['task_editor_type'] ) || ! in_array( $input['task_editor_type'], $valid_editors, true ) ) {
+			$input['task_editor_type'] = 'quill';
+		}
+
+		// Validate alert message.
+		$input['alert_message'] = $this->validate_alert_message( $input );
+
+		// Validate ignored users.
+		$input['ignored_users'] = $this->validate_ignored_users( $input );
+
+		return $input;
+	}
+
+	/**
+	 * Strip Legacy OpenAI Fields.
+	 *
+	 * Removes the deprecated openai_* keys that are no longer stored.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return array The input array without the legacy OpenAI keys.
+	 */
+	private function strip_legacy_openai_fields( array $input ) {
+		unset(
+			$input['openai_api_url'],
+			$input['openai_api_key'],
+			$input['openai_model']
+		);
+
+		return $input;
+	}
+
+	/**
+	 * Sanitize Checkbox.
+	 *
+	 * Returns '1' when the given key is present and strictly equals '1', else '0'.
+	 *
+	 * @param array  $input The input fields being validated.
+	 * @param string $key   The checkbox key to read.
+	 * @return string Either '1' or '0'.
+	 */
+	private function sanitize_checkbox( array $input, $key ) {
+		return isset( $input[ $key ] ) && '1' === $input[ $key ] ? '1' : '0';
+	}
+
+	/**
+	 * Validate Shared Key.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string The sanitized shared key, or '' when absent.
+	 */
+	private function validate_shared_key( array $input ) {
+		return isset( $input['shared_key'] ) ? sanitize_text_field( $input['shared_key'] ) : '';
+	}
+
+	/**
+	 * Validate AI API Key.
+	 *
+	 * Sanitizes a newly provided key, otherwise keeps the previously stored one.
+	 *
+	 * @param array $input          The input fields being validated.
+	 * @param array $current_values The currently stored settings option.
+	 * @return string The validated API key.
+	 */
+	private function validate_ai_api_key( array $input, array $current_values ) {
+		return isset( $input['ai_api_key'] ) && '' !== trim( $input['ai_api_key'] )
+			? Decker_AI_Manager::sanitize_api_key( $input['ai_api_key'] )
+			: Decker_AI_Manager::get_api_key( $current_values );
+	}
+
+	/**
+	 * Validate AI Model.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string The sanitized model name, or the default Gemini model.
+	 */
+	private function validate_ai_model( array $input ) {
+		return isset( $input['ai_model'] ) && '' !== trim( $input['ai_model'] )
+			? sanitize_text_field( $input['ai_model'] )
+			: Decker_AI_Manager::DEFAULT_GEMINI_MODEL;
+	}
+
+	/**
+	 * Validate AI Prompt.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string The sanitized prompt, or the default prompt template.
+	 */
+	private function validate_ai_prompt( array $input ) {
+		return isset( $input['ai_prompt'] ) && '' !== trim( $input['ai_prompt'] )
+			? sanitize_textarea_field( $input['ai_prompt'] )
+			: Decker::get_default_ai_prompt_template();
+	}
+
+	/**
+	 * Validate Signaling Server.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string The sanitized server URL, or the default public server.
+	 */
+	private function validate_signaling_server( array $input ) {
+		if ( isset( $input['signaling_server'] ) && ! empty( $input['signaling_server'] ) ) {
+			// Include wss protocol for WebSocket signaling servers.
+			return esc_url_raw( $input['signaling_server'], array( 'wss', 'ws', 'https', 'http' ) );
+		}
+
+		return 'wss://signaling.yjs.dev';
+	}
+
+	/**
+	 * Validate Alert Color.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string A valid alert color, defaulting to 'info'.
+	 */
+	private function validate_alert_color( array $input ) {
+		$valid_colors = array( 'success', 'danger', 'warning', 'info' );
+		if ( isset( $input['alert_color'] ) && ! in_array( $input['alert_color'], $valid_colors ) ) {
+			return 'info'; // Default to info if invalid.
+		}
+
+		return isset( $input['alert_color'] ) ? $input['alert_color'] : 'info';
+	}
+
+	/**
+	 * Validate Minimum User Profile.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string A valid role slug, defaulting to 'editor'.
+	 */
+	private function validate_minimum_user_profile( array $input ) {
+		$roles = wp_roles()->get_names();
+		if ( isset( $input['minimum_user_profile'] ) && ! array_key_exists( $input['minimum_user_profile'], $roles ) ) {
+			return 'editor'; // Default to editor if invalid.
+		}
+
+		return isset( $input['minimum_user_profile'] ) ? $input['minimum_user_profile'] : 'editor';
+	}
+
+	/**
+	 * Validate Alert Message.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string The filtered alert message, or '' when absent.
+	 */
+	private function validate_alert_message( array $input ) {
+		return isset( $input['alert_message'] ) ? wp_kses_post( $input['alert_message'] ) : '';
+	}
+
+	/**
+	 * Validate Ignored Users.
+	 *
+	 * Keeps numeric user IDs that resolve to an existing user, dropping the rest,
+	 * and stores a transient when numeric-but-nonexistent IDs are present.
+	 *
+	 * @param array $input The input fields being validated.
+	 * @return string A comma-separated list of valid user IDs, or '' when absent/none.
+	 */
+	private function validate_ignored_users( array $input ) {
+		// Initialize ignored_users if not set.
+		if ( ! isset( $input['ignored_users'] ) ) {
+			return '';
+		}
+
+		// Validate ignored users if not empty.
+		if ( empty( $input['ignored_users'] ) ) {
+			return $input['ignored_users'];
+		}
+
+		$user_ids = array_map( 'trim', explode( ',', $input['ignored_users'] ) );
+		$valid_user_ids = array();
+		$invalid_user_ids = array();
+
+		foreach ( $user_ids as $user_id ) {
+			if ( is_numeric( $user_id ) ) {
+				if ( get_user_by( 'id', $user_id ) ) {
+					$valid_user_ids[] = $user_id;
+				} else {
+					$invalid_user_ids[] = $user_id;
+				}
+			}
+		}
+
+		// Set transient if there were invalid IDs.
+		if ( ! empty( $invalid_user_ids ) ) {
+			set_transient( 'decker_invalid_user_ids', $invalid_user_ids, 45 );
+		}
+
+		return ! empty( $valid_user_ids ) ? implode( ',', $valid_user_ids ) : '';
+	}
+}

--- a/admin/class-decker-admin-settings.php
+++ b/admin/class-decker-admin-settings.php
@@ -257,5 +257,4 @@ class Decker_Admin_Settings {
 	public function settings_validate( $input ) {
 		return $this->validator->validate( $input, get_option( 'decker_settings', array() ) );
 	}
-
 }

--- a/admin/class-decker-admin-settings.php
+++ b/admin/class-decker-admin-settings.php
@@ -18,272 +18,29 @@ defined( 'ABSPATH' ) || exit;
 class Decker_Admin_Settings {
 
 	/**
+	 * Renders the settings fields.
+	 *
+	 * @var Decker_Admin_Settings_Fields
+	 */
+	private $fields;
+
+	/**
+	 * Validates settings submissions.
+	 *
+	 * @var Decker_Admin_Settings_Validator
+	 */
+	private $validator;
+
+	/**
 	 * Constructor
 	 *
 	 * Initializes the class by defining hooks.
 	 */
 	public function __construct() {
+		$this->fields    = new Decker_Admin_Settings_Fields();
+		$this->validator = new Decker_Admin_Settings_Validator();
+
 		$this->define_hooks();
-	}
-
-	/**
-	 * Render Shared Key Field
-	 *
-	 * Outputs the HTML for the shared_key field, generating it only if it does not exist or does not meet the criteria.
-	 */
-	public function shared_key_render() {
-		$options = get_option( 'decker_settings', array() );
-
-		// Generate a new shared key (UUID) only if it does not exist or does not meet criteria.
-		if ( empty( $options['shared_key'] ) ) {
-			$options['shared_key'] = wp_generate_uuid4();
-			// Save the newly generated UUID back to the options.
-			update_option( 'decker_settings', $options );
-		}
-
-		$value = sanitize_text_field( $options['shared_key'] );
-		echo '<input type="text" name="decker_settings[shared_key]" pattern=".{8,}" value="' . esc_attr( $value ) . '" class="regular-text" pattern="" title="The key must be at least 8 characters long and include letters, numbers, and symbols." required>';
-		echo '<p class="description">' . esc_html__( 'Provide the Bearer token in the Authorization header for the email-to-post endpoint. Example request:', 'decker' ) . '</p>';
-		echo '<pre style="background: #f5f5f5; padding: 10px; border: 1px solid #ccc; border-radius: 4px;">';
-		echo 'POST ' . esc_url( get_site_url() ) . '/wp-json/decker/v1/email-to-post';
-		echo "\nHeader: Authorization: Bearer YOUR_SHARED_KEY";
-		echo '</pre>';
-	}
-
-	/**
-	 * Render Allow Email Notifications Field.
-	 *
-	 * Outputs the HTML for the allow_email_notifications field.
-	 */
-	public function allow_email_notifications_render() {
-		$options = get_option( 'decker_settings', array() );
-		$checked = isset( $options['allow_email_notifications'] ) && '1' === $options['allow_email_notifications'];
-
-		echo '<label>';
-		echo '<input type="checkbox" name="decker_settings[allow_email_notifications]" value="1" ' . checked( $checked, true, false ) . '>';
-		echo esc_html__( 'Enable email notifications for all plugin events.', 'decker' );
-		echo '</label>';
-		echo '<p class="description">' . esc_html__( 'This setting allows users to manage email notifications in their profile. By default, all notifications are enabled.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render Collaborative Editing Field.
-	 *
-	 * Outputs the HTML for the collaborative_editing field.
-	 */
-	public function collaborative_editing_render() {
-		$options = get_option( 'decker_settings', array() );
-		$checked = isset( $options['collaborative_editing'] ) && '1' === $options['collaborative_editing'];
-
-		echo '<label>';
-		echo '<input type="checkbox" name="decker_settings[collaborative_editing]" value="1" ' . checked( $checked, true, false ) . '>';
-		echo esc_html__( 'Enable real-time collaborative editing for tasks.', 'decker' );
-		echo '</label>';
-		echo '<p class="description">' . esc_html__( 'When enabled, multiple users can edit the same task simultaneously with real-time synchronization using WebRTC.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render Board Status Indicators Field.
-	 *
-	 * Outputs a browser-local preference for the board status indicators.
-	 */
-	public function sidebar_board_status_render() {
-		echo '<label for="sidebar-board-status-check">';
-		echo '<input type="checkbox" id="sidebar-board-status-check" value="1" checked data-decker-persistent aria-describedby="sidebar-board-status-description"> ';
-		echo esc_html__( 'Show board status indicators', 'decker' );
-		echo '</label>';
-		echo '<p class="description" id="sidebar-board-status-description">' . esc_html__( 'This preference is saved only in this browser.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render AI Enabled Field.
-	 *
-	 * Outputs the HTML for the ai_enabled field.
-	 *
-	 * @return void
-	 */
-	public function ai_enabled_render() {
-		$options = get_option( 'decker_settings', array() );
-		$checked = isset( $options['ai_enabled'] ) && '1' === $options['ai_enabled'];
-
-		echo '<label>';
-		echo '<input type="checkbox" name="decker_settings[ai_enabled]" value="1" ' . checked( $checked, true, false ) . '>';
-		echo esc_html__( 'Enable AI improvements for task descriptions.', 'decker' );
-		echo '</label>';
-		echo '<p class="description">' . esc_html__( 'When enabled, users can improve task descriptions with either Gemini Nano in supported browsers or the Gemini API through the server.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render AI Provider Field.
-	 *
-	 * Outputs the HTML for the ai_provider field.
-	 *
-	 * @return void
-	 */
-	public function ai_provider_render() {
-		$options  = get_option( 'decker_settings', array() );
-		$provider = Decker_AI_Manager::get_selected_provider( $options );
-		$choices  = array(
-			Decker_AI_Manager::PROVIDER_BROWSER_GEMINI_NANO => __(
-				'Gemini Nano (browser-based)',
-				'decker'
-			),
-			Decker_AI_Manager::PROVIDER_GEMINI_API          => __(
-				'Gemini API (server-side)',
-				'decker'
-			),
-		);
-
-		foreach ( $choices as $value => $label ) {
-			echo '<p><label>';
-			echo '<input type="radio" name="decker_settings[ai_provider]" value="' . esc_attr( $value ) . '" ' . checked( $provider, $value, false ) . '>';
-			echo esc_html( $label );
-			echo '</label></p>';
-		}
-
-		echo '<p class="description">' . esc_html__( 'Choose whether AI improvements run in the browser with Gemini Nano or through the Gemini API on the server.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render AI API Key Field.
-	 *
-	 * Outputs the HTML for the ai_api_key field.
-	 *
-	 * @return void
-	 */
-	public function ai_api_key_render() {
-		$options        = get_option( 'decker_settings', array() );
-		$has_saved_key  = ! empty( $options['ai_api_key'] );
-		$placeholder    = $has_saved_key ? '••••••••••••••••' : '';
-		$description    = $has_saved_key
-			? __( 'A Gemini API key is already stored. Leave this field empty to keep the current key.', 'decker' )
-			: __( 'Paste a Gemini API key to enable server-side Gemini requests. The saved key is never shown again after saving.', 'decker' );
-
-		echo '<input type="password" name="decker_settings[ai_api_key]" class="regular-text" value="" autocomplete="off" placeholder="' . esc_attr( $placeholder ) . '">';
-		echo '<p class="description">' . esc_html( $description ) . '</p>';
-	}
-
-	/**
-	 * Render AI Model Field.
-	 *
-	 * Outputs the HTML for the ai_model field.
-	 *
-	 * @return void
-	 */
-	public function ai_model_render() {
-		$options = get_option( 'decker_settings', array() );
-		$value   = Decker_AI_Manager::get_model( $options );
-
-		echo '<input type="text" name="decker_settings[ai_model]" class="regular-text" value="' . esc_attr( $value ) . '" placeholder="' . esc_attr( Decker_AI_Manager::DEFAULT_GEMINI_MODEL ) . '">';
-		echo '<p class="description">' . esc_html__( 'Optional Gemini model name for server-side requests. Leave the default unless you need a different compatible text-generation model.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render AI Prompt Field.
-	 *
-	 * Outputs the HTML for the ai_prompt field.
-	 *
-	 * @return void
-	 */
-	public function ai_prompt_render() {
-		$options = get_option( 'decker_settings', array() );
-		$value   = isset( $options['ai_prompt'] ) && '' !== $options['ai_prompt']
-			? sanitize_textarea_field( $options['ai_prompt'] )
-			: Decker::get_default_ai_prompt_template();
-
-		echo '<textarea name="decker_settings[ai_prompt]" class="large-text code" rows="12">' . esc_textarea( $value ) . '</textarea>';
-		echo '<p class="description">' . esc_html__( 'Customize the base prompt used for AI improvements. For smaller nano-class models, it usually works better to write this base prompt in English and let the model translate the final result into the WordPress language. Available placeholders: {{mode_instruction}}, {{task_context}}, {{content_html}}, {{language_instruction}}, {{response_format}}.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render Signaling Server Field.
-	 *
-	 * Outputs the HTML for the signaling_server field.
-	 */
-	public function signaling_server_render() {
-		$options = get_option( 'decker_settings', array() );
-		$value   = isset( $options['signaling_server'] ) ? sanitize_text_field( $options['signaling_server'] ) : 'wss://signaling.yjs.dev';
-
-		echo '<input type="url" name="decker_settings[signaling_server]" class="regular-text" value="' . esc_attr( $value ) . '" placeholder="wss://signaling.yjs.dev">';
-		echo '<p class="description">' . esc_html__( 'WebRTC signaling server URL for collaborative editing. Leave empty to use the default public server (wss://signaling.yjs.dev).', 'decker' ) . '</p>';
-		echo '<p class="description"><strong>' . esc_html__( 'Public servers:', 'decker' ) . '</strong></p>';
-		echo '<ul class="description" style="list-style: disc; margin-left: 20px;">';
-		echo '<li><code>wss://signaling.yjs.dev</code> ' . esc_html__( '(Default - Global)', 'decker' ) . '</li>';
-		echo '<li><code>wss://y-webrtc-signaling-eu.herokuapp.com</code> ' . esc_html__( '(Europe)', 'decker' ) . '</li>';
-		echo '<li><code>wss://y-webrtc-signaling-us.herokuapp.com</code> ' . esc_html__( '(United States)', 'decker' ) . '</li>';
-		echo '</ul>';
-	}
-
-	/**
-	 * Render User Profile Field.
-	 *
-	 * Outputs the HTML for the minimum_user_profile field, displaying only roles with edit permissions.
-	 */
-	public function minimum_user_profile_render() {
-		// Get saved plugin options.
-		$options       = get_option( 'decker_settings', array() );
-
-		// Default to 'editor' if no user profile is selected.
-		$selected_role = isset( $options['minimum_user_profile'] ) && ! empty( $options['minimum_user_profile'] ) ? $options['minimum_user_profile'] : 'editor';
-
-		// Retrieve all registered roles in WordPress.
-		$roles = wp_roles()->roles;
-
-		// Filter roles to include only those with 'edit_posts' capability.
-		$editable_roles = array_filter(
-			$roles,
-			function ( $role ) {
-				return isset( $role['capabilities']['edit_posts'] ) && $role['capabilities']['edit_posts'];
-			}
-		);
-
-		// Render the select dropdown for user profiles.
-		echo '<select name="decker_settings[minimum_user_profile]" id="minimum_user_profile">';
-		foreach ( $editable_roles as $role_value => $role_data ) {
-			echo '<option value="' . esc_attr( $role_value ) . '" ' . selected( $selected_role, $role_value, false ) . '>' . esc_html( $role_data['name'] ) . '</option>';
-		}
-		echo '</select>';
-
-		// Add a description below the dropdown.
-		echo '<p class="description">' . esc_html__( 'Select the minimum user profile that can use Decker.', 'decker' ) . '</p>';
-	}
-
-
-	/**
-	 * Render Alert Message Field.
-	 *
-	 * Outputs the HTML for the alert_message field.
-	 */
-	public function alert_message_render() {
-		$options = get_option( 'decker_settings', array() );
-		$value   = isset( $options['alert_message'] ) ? wp_kses_post( $options['alert_message'] ) : '';
-		echo '<textarea name="decker_settings[alert_message]" class="large-text" rows="5">' . esc_textarea( $value ) . '</textarea>';
-		echo '<p class="description">' . esc_html__( 'Enter the alert message to display as a banner. Supports HTML. Leave empty to hide.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render Alert Color Field.
-	 *
-	 * Outputs the HTML for the alert_color field.
-	 */
-	public function alert_color_render() {
-		$options = get_option( 'decker_settings', array() );
-		$color   = isset( $options['alert_color'] ) ? $options['alert_color'] : 'info';
-
-		$colors = array(
-			'success' => 'Success',
-			'danger'  => 'Danger',
-			'warning' => 'Warning',
-			'info'    => 'Info',
-		);
-
-		foreach ( $colors as $value => $label ) {
-			echo '<label style="margin-right: 15px;">';
-			echo '<input type="radio" name="decker_settings[alert_color]" value="' . esc_attr( $value ) . '" ' . checked( $color, $value, false ) . '>';
-			echo esc_html( $label );
-			echo '</label>';
-		}
-		echo '<p class="description">' . esc_html__( 'Select the color for the alert message.', 'decker' ) . '</p>';
 	}
 
 	/**
@@ -387,14 +144,14 @@ class Decker_Admin_Settings {
 		add_settings_section(
 			'decker_main_section',
 			__( 'Decker Configuration', 'decker' ),
-			array( $this, 'settings_section_callback' ),
+			array( $this->fields, 'settings_section_callback' ),
 			'decker'
 		);
 
 		add_settings_section(
 			'decker_ai_section',
 			__( 'AI Configuration', 'decker' ),
-			array( $this, 'ai_settings_section_callback' ),
+			array( $this->fields, 'ai_settings_section_callback' ),
 			'decker'
 		);
 
@@ -416,9 +173,10 @@ class Decker_Admin_Settings {
 			add_settings_field(
 				$field_id,
 				$field_title,
-				array( $this, $field_id . '_render' ),
+				array( $this->fields, 'render' ),
 				'decker',
-				'decker_main_section'
+				'decker_main_section',
+				array( 'field' => $field_id )
 			);
 		}
 
@@ -434,86 +192,19 @@ class Decker_Admin_Settings {
 			add_settings_field(
 				$field_id,
 				$field_title,
-				array( $this, $field_id . '_render' ),
+				array( $this->fields, 'render' ),
 				'decker',
-				'decker_ai_section'
+				'decker_ai_section',
+				array( 'field' => $field_id )
 			);
 		}
 	}
 
 	/**
-	 * Settings Section Callback.
-	 *
-	 * Outputs a description for the settings section.
-	 */
-	public function settings_section_callback() {
-		echo '<p>' . esc_html__( 'Configure the Decker plugin settings.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * AI Settings Section Callback.
-	 *
-	 * Outputs a description for the AI settings section.
-	 *
-	 * @return void
-	 */
-	public function ai_settings_section_callback() {
-		echo '<p>' . esc_html__( 'Configure how Decker improves task descriptions with AI. Browser-based Gemini Nano keeps the text in the browser, while the Gemini API sends the prompt to Google through your WordPress server using the saved API key.', 'decker' ) . '</p>';
-	}
-
-
-
-
-	/**
 	 * Render Clear All Data Button.
 	 *
 	 * Outputs the HTML for the clear_all_data_button field.
 	 */
-	/**
-	 * Render Ignored Users Field.
-	 *
-	 * Outputs the HTML for the ignored_users field.
-	 */
-	public function ignored_users_render() {
-		$options = get_option( 'decker_settings', array() );
-		$value = isset( $options['ignored_users'] ) ? sanitize_text_field( $options['ignored_users'] ) : '';
-		echo '<input type="text" name="decker_settings[ignored_users]" class="regular-text" value="' . esc_attr( $value ) . '" pattern="^[0-9]+(,[0-9]+)*$" title="' . esc_attr__( 'Please enter comma-separated user IDs (numbers only)', 'decker' ) . '">';
-		echo '<p class="description">' . esc_html__( 'Enter comma-separated user IDs to ignore from Decker functionality.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render Task Editor Type Field.
-	 *
-	 * Outputs the HTML for the task_editor_type field.
-	 */
-	public function task_editor_type_render() {
-		$options     = get_option( 'decker_settings', array() );
-		$editor_type = isset( $options['task_editor_type'] ) ? $options['task_editor_type'] : 'quill';
-		$editors     = array(
-			'classic' => __( 'Classic Editor', 'decker' ),
-			'quill'   => __( 'Quill Editor', 'decker' ),
-		);
-
-		foreach ( $editors as $value => $label ) {
-			echo '<label style="margin-right: 15px;">';
-			echo '<input type="radio" name="decker_settings[task_editor_type]" value="' . esc_attr( $value ) . '" ' . checked( $editor_type, $value, false ) . '>';
-			echo esc_html( $label );
-			echo '</label>';
-		}
-
-		echo '<p class="description">' . esc_html__( 'Choose which editor to use for task descriptions. Collaborative editing always uses Quill.', 'decker' ) . '</p>';
-	}
-
-	/**
-	 * Render Clear All Data Button.
-	 *
-	 * Outputs the HTML for the clear_all_data_button field.
-	 */
-	public function clear_all_data_button_render() {
-		wp_nonce_field( 'decker_clear_all_data_action', 'decker_clear_all_data_nonce', true, true );
-		echo '<input type="submit" name="decker_clear_all_data" class="button button-secondary" style="background-color: red; color: white;" value="' . esc_attr__( 'Clear All Data', 'decker' ) . '" onclick="return confirm(\'' . esc_js( __( 'Are you sure you want to delete all Decker records? This action cannot be undone.', 'decker' ) ) . '\');">';
-		echo '<p class="description">' . esc_html__( 'Click the button to delete all Decker labels, tasks, and boards.', 'decker' ) . '</p>';
-	}
 
 	/**
 	 * Options Page.
@@ -564,225 +255,7 @@ class Decker_Admin_Settings {
 	 * @return array The validated fields.
 	 */
 	public function settings_validate( $input ) {
-		$input          = is_array( $input ) ? $input : array();
-		$current_values = get_option( 'decker_settings', array() );
-
-		$input = $this->strip_legacy_openai_fields( $input );
-
-		// Validate shared key.
-		$input['shared_key'] = $this->validate_shared_key( $input );
-
-		// Validate allow email notifications.
-		$input['allow_email_notifications'] = $this->sanitize_checkbox( $input, 'allow_email_notifications' );
-
-		// Validate collaborative editing.
-		$input['collaborative_editing'] = $this->sanitize_checkbox( $input, 'collaborative_editing' );
-
-		// Validate AI settings.
-		$input['ai_enabled']  = $this->sanitize_checkbox( $input, 'ai_enabled' );
-		$input['ai_provider'] = Decker_AI_Manager::get_selected_provider( $input );
-		$input['ai_api_key']  = $this->validate_ai_api_key( $input, $current_values );
-		$input['ai_model']    = $this->validate_ai_model( $input );
-		$input['ai_prompt']   = $this->validate_ai_prompt( $input );
-
-		// Validate signaling server.
-		$input['signaling_server'] = $this->validate_signaling_server( $input );
-
-		// Validate alert color.
-		$input['alert_color'] = $this->validate_alert_color( $input );
-
-		// Validate user profile.
-		$input['minimum_user_profile'] = $this->validate_minimum_user_profile( $input );
-
-		// Validate task editor type. Quill stays the default during the transition period.
-		$valid_editors = array( 'classic', 'quill' );
-		if ( ! isset( $input['task_editor_type'] ) || ! in_array( $input['task_editor_type'], $valid_editors, true ) ) {
-			$input['task_editor_type'] = 'quill';
-		}
-
-		// Validate alert message.
-		$input['alert_message'] = $this->validate_alert_message( $input );
-
-		// Validate ignored users.
-		$input['ignored_users'] = $this->validate_ignored_users( $input );
-
-		return $input;
+		return $this->validator->validate( $input, get_option( 'decker_settings', array() ) );
 	}
 
-	/**
-	 * Strip Legacy OpenAI Fields.
-	 *
-	 * Removes the deprecated openai_* keys that are no longer stored.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return array The input array without the legacy OpenAI keys.
-	 */
-	private function strip_legacy_openai_fields( array $input ) {
-		unset(
-			$input['openai_api_url'],
-			$input['openai_api_key'],
-			$input['openai_model']
-		);
-
-		return $input;
-	}
-
-	/**
-	 * Sanitize Checkbox.
-	 *
-	 * Returns '1' when the given key is present and strictly equals '1', else '0'.
-	 *
-	 * @param array  $input The input fields being validated.
-	 * @param string $key   The checkbox key to read.
-	 * @return string Either '1' or '0'.
-	 */
-	private function sanitize_checkbox( array $input, $key ) {
-		return isset( $input[ $key ] ) && '1' === $input[ $key ] ? '1' : '0';
-	}
-
-	/**
-	 * Validate Shared Key.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string The sanitized shared key, or '' when absent.
-	 */
-	private function validate_shared_key( array $input ) {
-		return isset( $input['shared_key'] ) ? sanitize_text_field( $input['shared_key'] ) : '';
-	}
-
-	/**
-	 * Validate AI API Key.
-	 *
-	 * Sanitizes a newly provided key, otherwise keeps the previously stored one.
-	 *
-	 * @param array $input          The input fields being validated.
-	 * @param array $current_values The currently stored settings option.
-	 * @return string The validated API key.
-	 */
-	private function validate_ai_api_key( array $input, array $current_values ) {
-		return isset( $input['ai_api_key'] ) && '' !== trim( $input['ai_api_key'] )
-			? Decker_AI_Manager::sanitize_api_key( $input['ai_api_key'] )
-			: Decker_AI_Manager::get_api_key( $current_values );
-	}
-
-	/**
-	 * Validate AI Model.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string The sanitized model name, or the default Gemini model.
-	 */
-	private function validate_ai_model( array $input ) {
-		return isset( $input['ai_model'] ) && '' !== trim( $input['ai_model'] )
-			? sanitize_text_field( $input['ai_model'] )
-			: Decker_AI_Manager::DEFAULT_GEMINI_MODEL;
-	}
-
-	/**
-	 * Validate AI Prompt.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string The sanitized prompt, or the default prompt template.
-	 */
-	private function validate_ai_prompt( array $input ) {
-		return isset( $input['ai_prompt'] ) && '' !== trim( $input['ai_prompt'] )
-			? sanitize_textarea_field( $input['ai_prompt'] )
-			: Decker::get_default_ai_prompt_template();
-	}
-
-	/**
-	 * Validate Signaling Server.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string The sanitized server URL, or the default public server.
-	 */
-	private function validate_signaling_server( array $input ) {
-		if ( isset( $input['signaling_server'] ) && ! empty( $input['signaling_server'] ) ) {
-			// Include wss protocol for WebSocket signaling servers.
-			return esc_url_raw( $input['signaling_server'], array( 'wss', 'ws', 'https', 'http' ) );
-		}
-
-		return 'wss://signaling.yjs.dev';
-	}
-
-	/**
-	 * Validate Alert Color.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string A valid alert color, defaulting to 'info'.
-	 */
-	private function validate_alert_color( array $input ) {
-		$valid_colors = array( 'success', 'danger', 'warning', 'info' );
-		if ( isset( $input['alert_color'] ) && ! in_array( $input['alert_color'], $valid_colors ) ) {
-			return 'info'; // Default to info if invalid.
-		}
-
-		return isset( $input['alert_color'] ) ? $input['alert_color'] : 'info';
-	}
-
-	/**
-	 * Validate Minimum User Profile.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string A valid role slug, defaulting to 'editor'.
-	 */
-	private function validate_minimum_user_profile( array $input ) {
-		$roles = wp_roles()->get_names();
-		if ( isset( $input['minimum_user_profile'] ) && ! array_key_exists( $input['minimum_user_profile'], $roles ) ) {
-			return 'editor'; // Default to editor if invalid.
-		}
-
-		return isset( $input['minimum_user_profile'] ) ? $input['minimum_user_profile'] : 'editor';
-	}
-
-	/**
-	 * Validate Alert Message.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string The filtered alert message, or '' when absent.
-	 */
-	private function validate_alert_message( array $input ) {
-		return isset( $input['alert_message'] ) ? wp_kses_post( $input['alert_message'] ) : '';
-	}
-
-	/**
-	 * Validate Ignored Users.
-	 *
-	 * Keeps numeric user IDs that resolve to an existing user, dropping the rest,
-	 * and stores a transient when numeric-but-nonexistent IDs are present.
-	 *
-	 * @param array $input The input fields being validated.
-	 * @return string A comma-separated list of valid user IDs, or '' when absent/none.
-	 */
-	private function validate_ignored_users( array $input ) {
-		// Initialize ignored_users if not set.
-		if ( ! isset( $input['ignored_users'] ) ) {
-			return '';
-		}
-
-		// Validate ignored users if not empty.
-		if ( empty( $input['ignored_users'] ) ) {
-			return $input['ignored_users'];
-		}
-
-		$user_ids = array_map( 'trim', explode( ',', $input['ignored_users'] ) );
-		$valid_user_ids = array();
-		$invalid_user_ids = array();
-
-		foreach ( $user_ids as $user_id ) {
-			if ( is_numeric( $user_id ) ) {
-				if ( get_user_by( 'id', $user_id ) ) {
-					$valid_user_ids[] = $user_id;
-				} else {
-					$invalid_user_ids[] = $user_id;
-				}
-			}
-		}
-
-		// Set transient if there were invalid IDs.
-		if ( ! empty( $invalid_user_ids ) ) {
-			set_transient( 'decker_invalid_user_ids', $invalid_user_ids, 45 );
-		}
-
-		return ! empty( $valid_user_ids ) ? implode( ',', $valid_user_ids ) : '';
-	}
 }

--- a/admin/class-decker-admin-settings.php
+++ b/admin/class-decker-admin-settings.php
@@ -201,12 +201,6 @@ class Decker_Admin_Settings {
 	}
 
 	/**
-	 * Render Clear All Data Button.
-	 *
-	 * Outputs the HTML for the clear_all_data_button field.
-	 */
-
-	/**
 	 * Options Page.
 	 *
 	 * Renders the settings page.

--- a/admin/class-decker-admin.php
+++ b/admin/class-decker-admin.php
@@ -96,6 +96,8 @@ class Decker_Admin {
 	 * @access   private
 	 */
 	private function load_dependencies() {
+		require_once plugin_dir_path( __DIR__ ) . 'admin/class-decker-admin-settings-fields.php';
+		require_once plugin_dir_path( __DIR__ ) . 'admin/class-decker-admin-settings-validator.php';
 		require_once plugin_dir_path( __DIR__ ) . 'admin/class-decker-admin-settings.php';
 
 		if ( ! has_action( 'admin_menu', array( 'Decker_Admin_Settings', 'create_menu' ) ) ) {

--- a/docs/development.md
+++ b/docs/development.md
@@ -78,6 +78,7 @@ the new one. None of these changed behaviour; only their owner changed.
 | `Decker_Admin_Settings::*_render()` (16 field renderers) / section callbacks | `Decker_Admin_Settings_Fields` (single public `render()` dispatcher) |
 | `Decker_Admin_Settings` private validators | `Decker_Admin_Settings_Validator::validate()` |
 | `Decker_Notification_Handler::add_notification_to_user()` / `remove_notification_from_user()` | `Decker_Notification_Store` |
+| `Decker_Notification_Handler::MAX_NOTIFICATIONS` (public constant) | `Decker_Notification_Store::MAX_NOTIFICATIONS` |
 | `Decker_Notification_Handler::heartbeat_received()` / `modify_heartbeat_settings()` / `ajax_*()` | `Decker_Notification_Ajax` |
 | `Decker_Public::enqueue_scripts()` body | `Decker_Public_Assets` |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,11 @@ the new one. None of these changed behaviour; only their owner changed.
 | `Decker_Labels::add_color_field()` / `edit_color_field()` / `save_color_meta()` | `Decker_Term_Color_Field` |
 | `Decker_Kb::track_last_editor()` / `get_last_editor()` / `get_latest_revision_id()` / `get_revision_admin_url()` | `Decker_Kb_Revisions` |
 | `Decker_Events::add_meta_boxes()` / `display_users_meta_box()` / `render_event_details_meta_box()` | `Decker_Event_Meta_Box` |
+| `Decker_Events::hide_visibility_options()` / `add_custom_columns()` / `render_custom_columns()` | `Decker_Event_Admin_Screen` |
+| `Decker_Admin_Settings::*_render()` (16 field renderers) / section callbacks | `Decker_Admin_Settings_Fields` (single public `render()` dispatcher) |
+| `Decker_Admin_Settings` private validators | `Decker_Admin_Settings_Validator::validate()` |
+| `Decker_Notification_Handler::add_notification_to_user()` / `remove_notification_from_user()` | `Decker_Notification_Store` |
+| `Decker_Notification_Handler::heartbeat_received()` / `modify_heartbeat_settings()` / `ajax_*()` | `Decker_Notification_Ajax` |
 | `Decker_Public::enqueue_scripts()` body | `Decker_Public_Assets` |
 
 Note that unhooking one of these by name fails **silently** rather than fatally:

--- a/includes/class-decker-notification-ajax.php
+++ b/includes/class-decker-notification-ajax.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Serves a user's Decker notifications to the browser.
+ *
+ * Owns the Heartbeat integration and the AJAX endpoints the notification
+ * panel calls; persistence and formatting are delegated to the store.
+ *
+ * @package Decker
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Decker_Notification_Ajax
+ */
+class Decker_Notification_Ajax {
+
+	/**
+	 * The notification store.
+	 *
+	 * @var Decker_Notification_Store
+	 */
+	private $store;
+
+	/**
+	 * Hook the Heartbeat filters and the AJAX endpoints.
+	 *
+	 * @param Decker_Notification_Store $store The notification store.
+	 */
+	public function __construct( Decker_Notification_Store $store ) {
+		$this->store = $store;
+
+		// Heartbeat hook.
+		add_filter( 'heartbeat_received', array( $this, 'heartbeat_received' ), 10, 3 );
+
+		add_filter( 'heartbeat_settings', array( $this, 'modify_heartbeat_settings' ), 10, 1 );
+
+		// AJAX hooks.
+		add_action( 'wp_ajax_get_decker_notifications', array( $this, 'ajax_get_decker_notifications' ) );
+		add_action( 'wp_ajax_clear_decker_notifications', array( $this, 'ajax_clear_decker_notifications' ) );
+		add_action( 'wp_ajax_remove_decker_notification', array( $this, 'ajax_remove_decker_notification' ) );
+		add_action( 'wp_ajax_send_test_notification', array( $this, 'ajax_send_test_notification' ) );
+	}
+
+	/**
+	 * Modifies the WordPress Heartbeat settings.
+	 *
+	 * Adjusts the heartbeat interval to n seconds.
+	 *
+	 * @param array $settings The existing Heartbeat settings.
+	 * @return array Modified Heartbeat settings with a new interval.
+	 */
+	public function modify_heartbeat_settings( $settings ) {
+		$settings['interval'] = 15; // Changed to 15 seconds.
+		return $settings;
+	}
+
+	/**
+	 * Process data from the Heartbeat API and add notifications to the response.
+	 *
+	 * @param array       $response Response data.
+	 * @param array       $data Data sent by the client.
+	 * @param string|null $screen_id Screen ID or null.
+	 *
+	 * @return array Modified response data with decker_notifications if any.
+	 */
+	public function heartbeat_received( $response, $data, $screen_id ) {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return $response;
+		}
+
+		$pending = $this->store->get_notifications_meta( $user_id, 'decker_pending_notifications' );
+		if ( empty( $pending ) ) {
+			return $response;
+		}
+
+		$response['decker_notifications'] = array();
+
+		foreach ( $pending as $notification ) {
+			// Prepare data for JS.
+			$response['decker_notifications'][] = $this->store->format_notification_for_heartbeat( $notification );
+		}
+
+		// Clear pending after sending them once.
+		delete_user_meta( $user_id, 'decker_pending_notifications' );
+
+		return $response;
+	}
+
+	/**
+	 * AJAX: Return the last 15 notifications from user meta.
+	 */
+	public function ajax_get_decker_notifications() {
+		check_ajax_referer( 'heartbeat-nonce', false, false ); // Optional, adjust if needed.
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			wp_send_json_error( 'Not logged in' );
+		}
+
+		$all_notifications = $this->store->get_notifications_meta( $user_id, 'decker_all_notifications' );
+
+		// Reverse so newest is at the front.
+		usort(
+			$all_notifications,
+			function ( $a, $b ) {
+				return strtotime( $a['time'] ) - strtotime( $b['time'] );
+			}
+		);
+		// Return only the last 15 (most recent first).
+		$last_notifications = array_slice( $all_notifications, 0, Decker_Notification_Store::MAX_NOTIFICATIONS );
+
+		// Map them to the same structure used in JS.
+		$formatted = array();
+		foreach ( $last_notifications as $notification ) {
+			$formatted[] = $this->store->format_notification_for_client( $notification, 'Notification' );
+		}
+
+		wp_send_json_success( $formatted );
+	}
+
+	/**
+	 * AJAX: Clear all notifications for current user.
+	 */
+	public function ajax_clear_decker_notifications() {
+		check_ajax_referer( 'heartbeat-nonce', false, false ); // Optional, adjust if needed.
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			wp_send_json_error( 'Not logged in' );
+		}
+
+		delete_user_meta( $user_id, 'decker_all_notifications' );
+		delete_user_meta( $user_id, 'decker_pending_notifications' );
+		wp_send_json_success( 'All notifications cleared' );
+	}
+
+	/**
+	 * AJAX: Remove one notification that has a matching task_id.
+	 */
+	public function ajax_remove_decker_notification() {
+		check_ajax_referer( 'heartbeat-nonce', false, false ); // Optional, adjust if needed.
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			wp_send_json_error( 'Not logged in' );
+		}
+
+		$task_id         = isset( $_POST['task_id'] ) ? intval( $_POST['task_id'] ) : 0;
+		$type            = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : '';
+		$notification_id = isset( $_POST['notification_id'] )
+			? sanitize_text_field( wp_unslash( $_POST['notification_id'] ) )
+			: '';
+
+		if ( ! $task_id && ! $type && ! $notification_id ) {
+			wp_send_json_error( 'No valid identifier provided' );
+		}
+
+		$notification_to_remove = array(
+			'type'            => $type,
+			'task_id'         => $task_id,
+			'notification_id' => $notification_id,
+		);
+		$this->store->remove_notification_from_user( $user_id, $notification_to_remove );
+
+		wp_send_json_success( 'Notification removed' );
+	}
+
+	/**
+	 * AJAX: Send test notification to all users (admin only).
+	 */
+	public function ajax_send_test_notification() {
+		check_ajax_referer( 'heartbeat-nonce', false, false );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'No permission' );
+		}
+
+		$message = isset( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
+		$user_id = isset( $_POST['user_id'] ) ? sanitize_text_field( wp_unslash( $_POST['user_id'] ) ) : 'all';
+		$type = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'info';
+
+		if ( empty( $message ) ) {
+			wp_send_json_error( 'Message cannot be empty' );
+		}
+
+		// Determine the users to notify.
+		$users_to_notify = ( 'all' === $user_id ) ? get_users( array( 'fields' => 'ID' ) ) : array( $user_id );
+
+		foreach ( $users_to_notify as $uid ) {
+			$this->store->add_notification_to_user(
+				$uid,
+				array(
+					'type'       => $type,
+					'task_id'    => 0,
+					'title'      => $message,
+					'action'     => 'Manual Notification',
+					'time'       => gmdate( 'Y-m-d H:i:s' ),
+					'url'        => '#',
+				)
+			);
+		}
+
+		wp_send_json_success( 'Notification sent successfully' );
+	}
+}

--- a/includes/class-decker-notification-handler.php
+++ b/includes/class-decker-notification-handler.php
@@ -34,13 +34,22 @@ class Decker_Notification_Handler {
 
 	/**
 	 * Constructor
+	 *
+	 * Both collaborators can be injected so tests exercise the exact instances
+	 * the handler persists through, instead of parallel ones that would
+	 * register the Heartbeat and AJAX hooks a second time.
+	 *
+	 * @param Decker_Notification_Store|null $store Optional store to persist through.
+	 * @param Decker_Notification_Ajax|null  $ajax  Optional browser-facing side; when given, its hooks are already registered and no second instance is created.
 	 */
-	public function __construct() {
+	public function __construct( $store = null, $ajax = null ) {
 		$this->mailer = new Decker_Mailer();
-		$this->store  = new Decker_Notification_Store();
+		$this->store  = $store instanceof Decker_Notification_Store ? $store : new Decker_Notification_Store();
 
-		// The browser-facing side (Heartbeat + AJAX) registers its own hooks.
-		new Decker_Notification_Ajax( $this->store );
+		if ( ! $ajax instanceof Decker_Notification_Ajax ) {
+			// The browser-facing side (Heartbeat + AJAX) registers its own hooks.
+			new Decker_Notification_Ajax( $this->store );
+		}
 
 		// Triggered when a new task is created.
 		add_action( 'decker_task_created', array( $this, 'handle_task_created' ) );

--- a/includes/class-decker-notification-handler.php
+++ b/includes/class-decker-notification-handler.php
@@ -18,18 +18,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Decker_Notification_Handler {
 
 	/**
-	 * Maximum notifications to keep in user meta.
-	 *
-	 * @var int
-	 */
-	const MAX_NOTIFICATIONS = 15;
-
-	/**
 	 * The mailer instance.
 	 *
 	 * @var Decker_Mailer
 	 */
 	public $mailer;
+
+	/**
+	 * The notification store.
+	 *
+	 * @var Decker_Notification_Store
+	 */
+	private $store;
 
 
 	/**
@@ -37,17 +37,10 @@ class Decker_Notification_Handler {
 	 */
 	public function __construct() {
 		$this->mailer = new Decker_Mailer();
+		$this->store  = new Decker_Notification_Store();
 
-		// Heartbeat hook.
-		add_filter( 'heartbeat_received', array( $this, 'heartbeat_received' ), 10, 3 );
-
-		add_filter( 'heartbeat_settings', array( $this, 'modify_heartbeat_settings' ), 10, 1 );
-
-		// AJAX hooks.
-		add_action( 'wp_ajax_get_decker_notifications', array( $this, 'ajax_get_decker_notifications' ) );
-		add_action( 'wp_ajax_clear_decker_notifications', array( $this, 'ajax_clear_decker_notifications' ) );
-		add_action( 'wp_ajax_remove_decker_notification', array( $this, 'ajax_remove_decker_notification' ) );
-		add_action( 'wp_ajax_send_test_notification', array( $this, 'ajax_send_test_notification' ) );
+		// The browser-facing side (Heartbeat + AJAX) registers its own hooks.
+		new Decker_Notification_Ajax( $this->store );
 
 		// Triggered when a new task is created.
 		add_action( 'decker_task_created', array( $this, 'handle_task_created' ) );
@@ -64,20 +57,6 @@ class Decker_Notification_Handler {
 		// Triggered when a responsable is changed.
 		add_action( 'decker_task_responsable_changed', array( $this, 'handle_responsable_changed' ), 10, 3 );
 	}
-
-	/**
-	 * Modifies the WordPress Heartbeat settings.
-	 *
-	 * Adjusts the heartbeat interval to n seconds.
-	 *
-	 * @param array $settings The existing Heartbeat settings.
-	 * @return array Modified Heartbeat settings with a new interval.
-	 */
-	public function modify_heartbeat_settings( $settings ) {
-		$settings['interval'] = 15; // Changed to 15 seconds.
-		return $settings;
-	}
-
 
 	/**
 	 * Checks if email notifications are enabled in the plugin settings.
@@ -198,7 +177,7 @@ class Decker_Notification_Handler {
 			}
 
 			// Store notification in user meta for Heartbeat and UI.
-			$this->add_notification_to_user(
+			$this->store->add_notification_to_user(
 				$user_id,
 				array(
 					'type'       => 'task_created',
@@ -266,7 +245,7 @@ class Decker_Notification_Handler {
 		/* error_log( 'Adding notification in handle_user_assigned() for user: ' . $user_id ); */
 
 		// Store notification in user meta for Heartbeat and UI.
-		$this->add_notification_to_user(
+		$this->store->add_notification_to_user(
 			$user_id,
 			array(
 				'type'       => 'task_assigned',
@@ -357,7 +336,7 @@ class Decker_Notification_Handler {
 		$finisher_name = $finisher ? $finisher->display_name : __( 'Unknown user', 'decker' );
 
 		// Store notification in user meta for Heartbeat and UI.
-		$this->add_notification_to_user(
+		$this->store->add_notification_to_user(
 			$user_id,
 			array(
 				'type'       => 'task_completed',
@@ -440,7 +419,7 @@ class Decker_Notification_Handler {
 		$author_name = $author ? $author->display_name : __( 'Unknown user', 'decker' );
 
 		// Store notification in user meta for Heartbeat and UI.
-		$this->add_notification_to_user(
+		$this->store->add_notification_to_user(
 			$user_id,
 			array(
 				'type'    => 'task_comment',
@@ -505,345 +484,4 @@ class Decker_Notification_Handler {
 		);
 	}
 
-	/**
-	 * Process data from the Heartbeat API and add notifications to the response.
-	 *
-	 * @param array       $response Response data.
-	 * @param array       $data Data sent by the client.
-	 * @param string|null $screen_id Screen ID or null.
-	 *
-	 * @return array Modified response data with decker_notifications if any.
-	 */
-	public function heartbeat_received( $response, $data, $screen_id ) {
-		$user_id = get_current_user_id();
-		if ( ! $user_id ) {
-			return $response;
-		}
-
-		$pending = $this->get_notifications_meta( $user_id, 'decker_pending_notifications' );
-		if ( empty( $pending ) ) {
-			return $response;
-		}
-
-		$response['decker_notifications'] = array();
-
-		foreach ( $pending as $notification ) {
-			// Prepare data for JS.
-			$response['decker_notifications'][] = $this->format_notification_for_heartbeat( $notification );
-		}
-
-		// Clear pending after sending them once.
-		delete_user_meta( $user_id, 'decker_pending_notifications' );
-
-		return $response;
-	}
-
-	/**
-	 * AJAX: Return the last 15 notifications from user meta.
-	 */
-	public function ajax_get_decker_notifications() {
-		check_ajax_referer( 'heartbeat-nonce', false, false ); // Optional, adjust if needed.
-		$user_id = get_current_user_id();
-		if ( ! $user_id ) {
-			wp_send_json_error( 'Not logged in' );
-		}
-
-		$all_notifications = $this->get_notifications_meta( $user_id, 'decker_all_notifications' );
-
-		// Reverse so newest is at the front.
-		usort(
-			$all_notifications,
-			function ( $a, $b ) {
-				return strtotime( $a['time'] ) - strtotime( $b['time'] );
-			}
-		);
-		// Return only the last 15 (most recent first).
-		$last_notifications = array_slice( $all_notifications, 0, self::MAX_NOTIFICATIONS );
-
-		// Map them to the same structure used in JS.
-		$formatted = array();
-		foreach ( $last_notifications as $notification ) {
-			$formatted[] = $this->format_notification_for_client( $notification, 'Notification' );
-		}
-
-		wp_send_json_success( $formatted );
-	}
-
-	/**
-	 * AJAX: Clear all notifications for current user.
-	 */
-	public function ajax_clear_decker_notifications() {
-		check_ajax_referer( 'heartbeat-nonce', false, false ); // Optional, adjust if needed.
-		$user_id = get_current_user_id();
-		if ( ! $user_id ) {
-			wp_send_json_error( 'Not logged in' );
-		}
-
-		delete_user_meta( $user_id, 'decker_all_notifications' );
-		delete_user_meta( $user_id, 'decker_pending_notifications' );
-		wp_send_json_success( 'All notifications cleared' );
-	}
-
-	/**
-	 * Removes a specific notification from user meta.
-	 *
-	 * @param int   $user_id User ID.
-	 * @param array $notification Notification data to remove.
-	 */
-	public function remove_notification_from_user( $user_id, $notification ) {
-		if ( ! $user_id ) {
-			return;
-		}
-
-		$all_notifications = get_user_meta( $user_id, 'decker_all_notifications', true );
-		if ( ! is_array( $all_notifications ) ) {
-			return;
-		}
-
-		$notification_id = isset( $notification['notification_id'] )
-			? sanitize_text_field( $notification['notification_id'] )
-			: '';
-
-		// Remove the notification matching type and task_id (if applicable).
-		$filtered = array_filter(
-			$all_notifications,
-			function ( $stored_notification ) use ( $notification, $notification_id ) {
-				if ( $notification_id ) {
-					return $this->get_notification_id( $stored_notification ) !== $notification_id;
-				}
-
-				return (
-					$stored_notification['type'] !== $notification['type']
-					|| ( isset( $stored_notification['task_id'] )
-					&& $stored_notification['task_id'] !== $notification['task_id'] )
-				);
-			}
-		);
-
-		update_user_meta( $user_id, 'decker_all_notifications', array_values( $filtered ) );
-	}
-
-	/**
-	 * AJAX: Remove one notification that has a matching task_id.
-	 */
-	public function ajax_remove_decker_notification() {
-		check_ajax_referer( 'heartbeat-nonce', false, false ); // Optional, adjust if needed.
-		$user_id = get_current_user_id();
-		if ( ! $user_id ) {
-			wp_send_json_error( 'Not logged in' );
-		}
-
-		$task_id         = isset( $_POST['task_id'] ) ? intval( $_POST['task_id'] ) : 0;
-		$type            = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : '';
-		$notification_id = isset( $_POST['notification_id'] )
-			? sanitize_text_field( wp_unslash( $_POST['notification_id'] ) )
-			: '';
-
-		if ( ! $task_id && ! $type && ! $notification_id ) {
-			wp_send_json_error( 'No valid identifier provided' );
-		}
-
-		$notification_to_remove = array(
-			'type'            => $type,
-			'task_id'         => $task_id,
-			'notification_id' => $notification_id,
-		);
-		$this->remove_notification_from_user( $user_id, $notification_to_remove );
-
-		wp_send_json_success( 'Notification removed' );
-	}
-
-	/**
-	 * AJAX: Send test notification to all users (admin only).
-	 */
-	public function ajax_send_test_notification() {
-		check_ajax_referer( 'heartbeat-nonce', false, false );
-
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( 'No permission' );
-		}
-
-		$message = isset( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
-		$user_id = isset( $_POST['user_id'] ) ? sanitize_text_field( wp_unslash( $_POST['user_id'] ) ) : 'all';
-		$type = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'info';
-
-		if ( empty( $message ) ) {
-			wp_send_json_error( 'Message cannot be empty' );
-		}
-
-		// Determine the users to notify.
-		$users_to_notify = ( 'all' === $user_id ) ? get_users( array( 'fields' => 'ID' ) ) : array( $user_id );
-
-		foreach ( $users_to_notify as $uid ) {
-			$this->add_notification_to_user(
-				$uid,
-				array(
-					'type'       => $type,
-					'task_id'    => 0,
-					'title'      => $message,
-					'action'     => 'Manual Notification',
-					'time'       => gmdate( 'Y-m-d H:i:s' ),
-					'url'        => '#',
-				)
-			);
-		}
-
-		wp_send_json_success( 'Notification sent successfully' );
-	}
-
-	/**
-	 * Add a notification to a user's "all notifications" meta,
-	 * and also store it in "pending" so Heartbeat can push it once.
-	 *
-	 * @param int   $user_id  User ID.
-	 * @param array $notification Notification data.
-	 */
-	public function add_notification_to_user( $user_id, $notification ) {
-		if ( ! $user_id ) {
-			return;
-		}
-
-		$notification['notification_id'] = $this->get_notification_id( $notification );
-
-		// Save to "all notifications".
-		$all_notifications = get_user_meta( $user_id, 'decker_all_notifications', true );
-		if ( ! is_array( $all_notifications ) ) {
-			$all_notifications = array();
-		}
-
-		// Append this new item at the end so we can limit by self::MAX_NOTIFICATIONS.
-		$all_notifications[] = $notification;
-
-		// Prune if over limit.
-		if ( count( $all_notifications ) > self::MAX_NOTIFICATIONS ) {
-			// Remove the oldest.
-			array_shift( $all_notifications );
-		}
-		update_user_meta( $user_id, 'decker_all_notifications', $all_notifications );
-
-		// Also store it in pending so it is sent via Heartbeat next cycle.
-		$pending = get_user_meta( $user_id, 'decker_pending_notifications', true );
-		if ( ! is_array( $pending ) ) {
-			$pending = array();
-		}
-
-		$pending[] = $notification;
-		update_user_meta( $user_id, 'decker_pending_notifications', $pending );
-	}
-
-	/**
-	 * Gets a stable identifier for a notification.
-	 *
-	 * @param array $notification Notification data.
-	 * @return string
-	 */
-	private function get_notification_id( $notification ) {
-		if ( ! empty( $notification['notification_id'] ) ) {
-			return sanitize_text_field( $notification['notification_id'] );
-		}
-
-		$identifier_data = array(
-			'type'    => isset( $notification['type'] ) ? (string) $notification['type'] : '',
-			'task_id' => isset( $notification['task_id'] ) ? (string) $notification['task_id'] : '',
-			'title'   => isset( $notification['title'] ) ? (string) $notification['title'] : '',
-			'action'  => isset( $notification['action'] ) ? (string) $notification['action'] : '',
-			'time'    => isset( $notification['time'] ) ? (string) $notification['time'] : '',
-			'url'     => isset( $notification['url'] ) ? (string) $notification['url'] : '',
-		);
-
-		return md5( wp_json_encode( $identifier_data ) );
-	}
-
-	/**
-	 * Retrieves a notifications meta value, normalized to an array.
-	 *
-	 * @param int    $user_id  The user ID.
-	 * @param string $meta_key The user meta key to read.
-	 * @return array The stored notifications, or an empty array when none are stored.
-	 */
-	private function get_notifications_meta( $user_id, $meta_key ) {
-		$notifications = get_user_meta( $user_id, $meta_key, true );
-		if ( ! is_array( $notifications ) ) {
-			return array();
-		}
-
-		return $notifications;
-	}
-
-	/**
-	 * Maps a stored notification to the structure consumed by the JS client.
-	 *
-	 * @param array  $notification  Notification data.
-	 * @param string $default_title Title fallback when the notification has none.
-	 * @return array The formatted notification payload.
-	 */
-	private function format_notification_for_client( $notification, $default_title ) {
-		return array(
-			'notificationId' => $this->get_notification_id( $notification ),
-			'url'       => isset( $notification['url'] ) ? $notification['url'] : '#',
-			'taskId'    => isset( $notification['task_id'] ) ? $notification['task_id'] : 0,
-			'iconColor' => $this->get_icon_color_by_type( $notification['type'] ),
-			'iconClass' => $this->get_icon_class_by_type( $notification['type'] ),
-			'title'     => isset( $notification['title'] ) ? $notification['title'] : $default_title,
-			'action'    => isset( $notification['action'] ) ? $notification['action'] : '',
-			'time'      => isset( $notification['time'] ) ? $notification['time'] : '',
-		);
-	}
-
-	/**
-	 * Maps a stored notification to the Heartbeat payload structure.
-	 *
-	 * Adds the heartbeat-only 'type' key and uses the heartbeat default title.
-	 *
-	 * @param array $notification Notification data.
-	 * @return array The formatted Heartbeat notification payload.
-	 */
-	private function format_notification_for_heartbeat( $notification ) {
-		$formatted         = $this->format_notification_for_client( $notification, 'New Notification' );
-		$formatted['type'] = isset( $notification['type'] ) ? $notification['type'] : '';
-
-		return $formatted;
-	}
-
-	/**
-	 * Maps notification type to icon color.
-	 *
-	 * @param string $type Notification type.
-	 * @return string
-	 */
-	private function get_icon_color_by_type( $type ) {
-		switch ( $type ) {
-			case 'task_created':
-				return 'primary';
-			case 'task_assigned':
-				return 'warning';
-			case 'task_completed':
-				return 'success';
-			case 'task_comment':
-				return 'info';
-			default:
-				return 'primary';
-		}
-	}
-
-	/**
-	 * Maps notification type to icon class.
-	 *
-	 * @param string $type Notification type.
-	 * @return string
-	 */
-	private function get_icon_class_by_type( $type ) {
-		switch ( $type ) {
-			case 'task_created':
-				return 'ri-add-line';
-			case 'task_assigned':
-				return 'ri-user-add-line';
-			case 'task_completed':
-				return 'ri-checkbox-circle-line';
-			case 'task_comment':
-				return 'ri-message-3-line';
-			default:
-				return 'ri-information-line';
-		}
-	}
 }

--- a/includes/class-decker-notification-handler.php
+++ b/includes/class-decker-notification-handler.php
@@ -483,5 +483,4 @@ class Decker_Notification_Handler {
 			$new_user->display_name
 		);
 	}
-
 }

--- a/includes/class-decker-notification-store.php
+++ b/includes/class-decker-notification-store.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Stores and formats a user's Decker notifications.
+ *
+ * Notifications live in user meta twice: the capped "all notifications" list
+ * the panel shows, and a "pending" list the next Heartbeat cycle drains. This
+ * class owns both, plus the mapping from a stored notification to the payload
+ * the JavaScript client consumes.
+ *
+ * @package Decker
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Decker_Notification_Store
+ */
+class Decker_Notification_Store {
+
+	/**
+	 * Maximum notifications to keep in user meta.
+	 *
+	 * @var int
+	 */
+	const MAX_NOTIFICATIONS = 15;
+
+	/**
+	 * Add a notification to a user's "all notifications" meta,
+	 * and also store it in "pending" so Heartbeat can push it once.
+	 *
+	 * @param int   $user_id  User ID.
+	 * @param array $notification Notification data.
+	 */
+	public function add_notification_to_user( $user_id, $notification ) {
+		if ( ! $user_id ) {
+			return;
+		}
+
+		$notification['notification_id'] = $this->get_notification_id( $notification );
+
+		// Save to "all notifications".
+		$all_notifications = get_user_meta( $user_id, 'decker_all_notifications', true );
+		if ( ! is_array( $all_notifications ) ) {
+			$all_notifications = array();
+		}
+
+		// Append this new item at the end so we can limit by self::MAX_NOTIFICATIONS.
+		$all_notifications[] = $notification;
+
+		// Prune if over limit.
+		if ( count( $all_notifications ) > self::MAX_NOTIFICATIONS ) {
+			// Remove the oldest.
+			array_shift( $all_notifications );
+		}
+		update_user_meta( $user_id, 'decker_all_notifications', $all_notifications );
+
+		// Also store it in pending so it is sent via Heartbeat next cycle.
+		$pending = get_user_meta( $user_id, 'decker_pending_notifications', true );
+		if ( ! is_array( $pending ) ) {
+			$pending = array();
+		}
+
+		$pending[] = $notification;
+		update_user_meta( $user_id, 'decker_pending_notifications', $pending );
+	}
+
+	/**
+	 * Removes a specific notification from user meta.
+	 *
+	 * @param int   $user_id User ID.
+	 * @param array $notification Notification data to remove.
+	 */
+	public function remove_notification_from_user( $user_id, $notification ) {
+		if ( ! $user_id ) {
+			return;
+		}
+
+		$all_notifications = get_user_meta( $user_id, 'decker_all_notifications', true );
+		if ( ! is_array( $all_notifications ) ) {
+			return;
+		}
+
+		$notification_id = isset( $notification['notification_id'] )
+			? sanitize_text_field( $notification['notification_id'] )
+			: '';
+
+		// Remove the notification matching type and task_id (if applicable).
+		$filtered = array_filter(
+			$all_notifications,
+			function ( $stored_notification ) use ( $notification, $notification_id ) {
+				if ( $notification_id ) {
+					return $this->get_notification_id( $stored_notification ) !== $notification_id;
+				}
+
+				return (
+					$stored_notification['type'] !== $notification['type']
+					|| ( isset( $stored_notification['task_id'] )
+					&& $stored_notification['task_id'] !== $notification['task_id'] )
+				);
+			}
+		);
+
+		update_user_meta( $user_id, 'decker_all_notifications', array_values( $filtered ) );
+	}
+
+	/**
+	 * Retrieves a notifications meta value, normalized to an array.
+	 *
+	 * @param int    $user_id  The user ID.
+	 * @param string $meta_key The user meta key to read.
+	 * @return array The stored notifications, or an empty array when none are stored.
+	 */
+	public function get_notifications_meta( $user_id, $meta_key ) {
+		$notifications = get_user_meta( $user_id, $meta_key, true );
+		if ( ! is_array( $notifications ) ) {
+			return array();
+		}
+
+		return $notifications;
+	}
+
+	/**
+	 * Maps a stored notification to the structure consumed by the JS client.
+	 *
+	 * @param array  $notification  Notification data.
+	 * @param string $default_title Title fallback when the notification has none.
+	 * @return array The formatted notification payload.
+	 */
+	public function format_notification_for_client( $notification, $default_title ) {
+		return array(
+			'notificationId' => $this->get_notification_id( $notification ),
+			'url'       => isset( $notification['url'] ) ? $notification['url'] : '#',
+			'taskId'    => isset( $notification['task_id'] ) ? $notification['task_id'] : 0,
+			'iconColor' => $this->get_icon_color_by_type( $notification['type'] ),
+			'iconClass' => $this->get_icon_class_by_type( $notification['type'] ),
+			'title'     => isset( $notification['title'] ) ? $notification['title'] : $default_title,
+			'action'    => isset( $notification['action'] ) ? $notification['action'] : '',
+			'time'      => isset( $notification['time'] ) ? $notification['time'] : '',
+		);
+	}
+
+	/**
+	 * Maps a stored notification to the Heartbeat payload structure.
+	 *
+	 * Adds the heartbeat-only 'type' key and uses the heartbeat default title.
+	 *
+	 * @param array $notification Notification data.
+	 * @return array The formatted Heartbeat notification payload.
+	 */
+	public function format_notification_for_heartbeat( $notification ) {
+		$formatted         = $this->format_notification_for_client( $notification, 'New Notification' );
+		$formatted['type'] = isset( $notification['type'] ) ? $notification['type'] : '';
+
+		return $formatted;
+	}
+
+	/**
+	 * Gets a stable identifier for a notification.
+	 *
+	 * @param array $notification Notification data.
+	 * @return string
+	 */
+	private function get_notification_id( $notification ) {
+		if ( ! empty( $notification['notification_id'] ) ) {
+			return sanitize_text_field( $notification['notification_id'] );
+		}
+
+		$identifier_data = array(
+			'type'    => isset( $notification['type'] ) ? (string) $notification['type'] : '',
+			'task_id' => isset( $notification['task_id'] ) ? (string) $notification['task_id'] : '',
+			'title'   => isset( $notification['title'] ) ? (string) $notification['title'] : '',
+			'action'  => isset( $notification['action'] ) ? (string) $notification['action'] : '',
+			'time'    => isset( $notification['time'] ) ? (string) $notification['time'] : '',
+			'url'     => isset( $notification['url'] ) ? (string) $notification['url'] : '',
+		);
+
+		return md5( wp_json_encode( $identifier_data ) );
+	}
+
+	/**
+	 * Maps notification type to icon color.
+	 *
+	 * @param string $type Notification type.
+	 * @return string
+	 */
+	private function get_icon_color_by_type( $type ) {
+		switch ( $type ) {
+			case 'task_created':
+				return 'primary';
+			case 'task_assigned':
+				return 'warning';
+			case 'task_completed':
+				return 'success';
+			case 'task_comment':
+				return 'info';
+			default:
+				return 'primary';
+		}
+	}
+
+	/**
+	 * Maps notification type to icon class.
+	 *
+	 * @param string $type Notification type.
+	 * @return string
+	 */
+	private function get_icon_class_by_type( $type ) {
+		switch ( $type ) {
+			case 'task_created':
+				return 'ri-add-line';
+			case 'task_assigned':
+				return 'ri-user-add-line';
+			case 'task_completed':
+				return 'ri-checkbox-circle-line';
+			case 'task_comment':
+				return 'ri-message-3-line';
+			default:
+				return 'ri-information-line';
+		}
+	}
+}

--- a/includes/class-decker.php
+++ b/includes/class-decker.php
@@ -144,6 +144,7 @@ class Decker {
 
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-tasks.php';
 
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-event-admin-screen.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-event-meta-box.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-events.php';
 

--- a/includes/class-decker.php
+++ b/includes/class-decker.php
@@ -161,6 +161,8 @@ class Decker {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-task-revision-manager.php';
 
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-mailer.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-notification-store.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-notification-ajax.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-notification-handler.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-ical-builder.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/class-decker-calendar.php';

--- a/includes/custom-post-types/class-decker-event-admin-screen.php
+++ b/includes/custom-post-types/class-decker-event-admin-screen.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Admin list-table presentation for events.
+ *
+ * The columns of the decker_event list table and the small CSS tweaks the
+ * edit screen needs. Presentation for administrators, kept apart from the
+ * post type registration and meta handling in Decker_Events.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Event_Admin_Screen
+ */
+class Decker_Event_Admin_Screen {
+
+	/**
+	 * Hook the list-table columns and the admin CSS tweaks.
+	 */
+	public function __construct() {
+		add_action( 'admin_head', array( $this, 'hide_visibility_options' ) );
+		add_filter( 'manage_decker_event_posts_columns', array( $this, 'add_custom_columns' ) );
+		add_action( 'manage_decker_event_posts_custom_column', array( $this, 'render_custom_columns' ), 10, 2 );
+	}
+
+	/**
+	 * Hide visibility options for decker_event post type.
+	 */
+	public function hide_visibility_options() {
+		$screen = get_current_screen();
+		if ( $screen && 'decker_event' === $screen->post_type ) {
+			echo '<style type="text/css">
+				.misc-pub-section.misc-pub-visibility {
+					display: none;
+				}
+			</style>';
+		}
+	}
+
+	/**
+	 * Add custom columns to the event admin list table.
+	 *
+	 * @param array $columns Existing columns.
+	 * @return array Modified columns.
+	 */
+	public function add_custom_columns( $columns ) {
+		   unset( $columns['date'] ); // Optional: remove the default date column.
+
+		$columns['event_allday'] = __( 'All Day Event', 'decker' );
+		$columns['event_start'] = __( 'Start', 'decker' );
+		$columns['event_end']   = __( 'End', 'decker' );
+		$columns['event_category'] = __( 'Category', 'decker' );
+
+		   $columns['date'] = __( 'Date', 'decker' ); // Add it again at the end.
+		return $columns;
+	}
+
+	/**
+	 * Render content for custom columns in the event admin list.
+	 *
+	 * @param string $column  Column name.
+	 * @param int    $post_id Post ID.
+	 */
+	public function render_custom_columns( $column, $post_id ) {
+		switch ( $column ) {
+			case 'event_allday':
+				$allday = get_post_meta( $post_id, 'event_allday', true );
+				printf(
+					'<input type="checkbox" disabled %s>',
+					checked( $allday, '1', false )
+				);
+				break;
+			case 'event_start':
+				$start = get_post_meta( $post_id, 'event_start', true );
+				echo esc_html( $start );
+				break;
+			case 'event_end':
+				$end = get_post_meta( $post_id, 'event_end', true );
+				echo esc_html( $end );
+				break;
+			case 'event_category':
+				$category = get_post_meta( $post_id, 'event_category', true );
+				echo esc_html( $category );
+				break;
+		}
+	}
+}

--- a/includes/custom-post-types/class-decker-events.php
+++ b/includes/custom-post-types/class-decker-events.php
@@ -21,19 +21,6 @@ class Decker_Events {
 		$this->define_hooks();
 	}
 
-	/**
-	 * Hide visibility options for decker_event post type.
-	 */
-	public function hide_visibility_options() {
-		$screen = get_current_screen();
-		if ( $screen && 'decker_event' === $screen->post_type ) {
-			echo '<style type="text/css">
-				.misc-pub-section.misc-pub-visibility {
-					display: none;
-				}
-			</style>';
-		}
-	}
 
 	/**
 	 * Define the hooks for the events custom post type
@@ -49,11 +36,11 @@ class Decker_Events {
 		add_filter( 'use_block_editor_for_post_type', array( $this, 'force_classic_editor' ), 10, 2 );
 
 		// Hide visibility options.
-		add_action( 'admin_head', array( $this, 'hide_visibility_options' ) );
+
+		// Admin list-table presentation owns its own hooks.
+		new Decker_Event_Admin_Screen();
 
 		// Add columns to admin.
-		add_filter( 'manage_decker_event_posts_columns', array( $this, 'add_custom_columns' ) );
-		add_action( 'manage_decker_event_posts_custom_column', array( $this, 'render_custom_columns' ), 10, 2 );
 
 		add_action( 'rest_after_insert_decker_event', array( $this, 'rest_fix_datetime_meta' ), 10, 3 );
 	}
@@ -307,55 +294,6 @@ class Decker_Events {
 			update_post_meta( $post->ID, 'event_end', $end );
 		}
 	}
-
-	/**
-	 * Add custom columns to the event admin list table.
-	 *
-	 * @param array $columns Existing columns.
-	 * @return array Modified columns.
-	 */
-	public function add_custom_columns( $columns ) {
-		   unset( $columns['date'] ); // Optional: remove the default date column.
-
-		$columns['event_allday'] = __( 'All Day Event', 'decker' );
-		$columns['event_start'] = __( 'Start', 'decker' );
-		$columns['event_end']   = __( 'End', 'decker' );
-		$columns['event_category'] = __( 'Category', 'decker' );
-
-		   $columns['date'] = __( 'Date', 'decker' ); // Add it again at the end.
-		return $columns;
-	}
-
-	/**
-	 * Render content for custom columns in the event admin list.
-	 *
-	 * @param string $column  Column name.
-	 * @param int    $post_id Post ID.
-	 */
-	public function render_custom_columns( $column, $post_id ) {
-		switch ( $column ) {
-			case 'event_allday':
-				$allday = get_post_meta( $post_id, 'event_allday', true );
-				printf(
-					'<input type="checkbox" disabled %s>',
-					checked( $allday, '1', false )
-				);
-				break;
-			case 'event_start':
-				$start = get_post_meta( $post_id, 'event_start', true );
-				echo esc_html( $start );
-				break;
-			case 'event_end':
-				$end = get_post_meta( $post_id, 'event_end', true );
-				echo esc_html( $end );
-				break;
-			case 'event_category':
-				$category = get_post_meta( $post_id, 'event_category', true );
-				echo esc_html( $category );
-				break;
-		}
-	}
-
 
 	/**
 	 * Process and save meta data from a data array.

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -33,6 +33,12 @@ msgstr ""
 msgid "https://www3.gobiernodecanarias.org/medusa/ecoescuela/ate/"
 msgstr ""
 
+msgid "Configure the Decker plugin settings."
+msgstr ""
+
+msgid "Configure how Decker improves task descriptions with AI. Browser-based Gemini Nano keeps the text in the browser, while the Gemini API sends the prompt to Google through your WordPress server using the saved API key."
+msgstr ""
+
 msgid "Provide the Bearer token in the Authorization header for the email-to-post endpoint. Example request:"
 msgstr ""
 
@@ -105,6 +111,30 @@ msgstr ""
 msgid "Select the color for the alert message."
 msgstr ""
 
+msgid "Please enter comma-separated user IDs (numbers only)"
+msgstr ""
+
+msgid "Enter comma-separated user IDs to ignore from Decker functionality."
+msgstr ""
+
+msgid "Classic Editor"
+msgstr ""
+
+msgid "Quill Editor"
+msgstr ""
+
+msgid "Choose which editor to use for task descriptions. Collaborative editing always uses Quill."
+msgstr ""
+
+msgid "Clear All Data"
+msgstr ""
+
+msgid "Are you sure you want to delete all Decker records? This action cannot be undone."
+msgstr ""
+
+msgid "Click the button to delete all Decker labels, tasks, and boards."
+msgstr ""
+
 msgid "Decker Settings"
 msgstr ""
 
@@ -141,9 +171,6 @@ msgstr ""
 msgid "Signaling Server"
 msgstr ""
 
-msgid "Clear All Data"
-msgstr ""
-
 msgid "Ignored Users"
 msgstr ""
 
@@ -160,33 +187,6 @@ msgid "Gemini Model"
 msgstr ""
 
 msgid "AI Prompt"
-msgstr ""
-
-msgid "Configure the Decker plugin settings."
-msgstr ""
-
-msgid "Configure how Decker improves task descriptions with AI. Browser-based Gemini Nano keeps the text in the browser, while the Gemini API sends the prompt to Google through your WordPress server using the saved API key."
-msgstr ""
-
-msgid "Please enter comma-separated user IDs (numbers only)"
-msgstr ""
-
-msgid "Enter comma-separated user IDs to ignore from Decker functionality."
-msgstr ""
-
-msgid "Classic Editor"
-msgstr ""
-
-msgid "Quill Editor"
-msgstr ""
-
-msgid "Choose which editor to use for task descriptions. Collaborative editing always uses Quill."
-msgstr ""
-
-msgid "Are you sure you want to delete all Decker records? This action cannot be undone."
-msgstr ""
-
-msgid "Click the button to delete all Decker labels, tasks, and boards."
 msgstr ""
 
 msgid "All Decker records have been deleted."
@@ -646,6 +646,21 @@ msgstr ""
 msgid "Color"
 msgstr ""
 
+msgid "All Day Event"
+msgstr ""
+
+msgid "Start"
+msgstr ""
+
+msgid "End"
+msgstr ""
+
+msgid "Category"
+msgstr ""
+
+msgid "Date"
+msgstr ""
+
 msgid "Event Details"
 msgstr ""
 
@@ -733,21 +748,6 @@ msgid "No events found in Trash."
 msgstr ""
 
 msgid "You do not have permission to access this resource."
-msgstr ""
-
-msgid "All Day Event"
-msgstr ""
-
-msgid "Start"
-msgstr ""
-
-msgid "End"
-msgstr ""
-
-msgid "Category"
-msgstr ""
-
-msgid "Date"
 msgstr ""
 
 msgid "Board is required"

--- a/tests/unit/admin/DeckerAdminSettingsScreenTest.php
+++ b/tests/unit/admin/DeckerAdminSettingsScreenTest.php
@@ -21,10 +21,27 @@ class DeckerAdminSettingsScreenTest extends Decker_Test_Base {
 	private $html;
 
 	/**
+	 * Settings API globals as they were before the test registered anything.
+	 *
+	 * Saved so tear_down() can put back exactly what was there, instead of
+	 * wiping registrations that belong to other tests.
+	 *
+	 * @var array
+	 */
+	private $saved_settings_globals;
+
+	/**
 	 * Set up before each test.
 	 */
 	public function set_up(): void {
 		parent::set_up();
+
+		global $wp_settings_sections, $wp_settings_fields, $wp_registered_settings;
+		$this->saved_settings_globals = array(
+			'sections'   => $wp_settings_sections,
+			'fields'     => $wp_settings_fields,
+			'registered' => $wp_registered_settings,
+		);
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 
@@ -48,9 +65,9 @@ class DeckerAdminSettingsScreenTest extends Decker_Test_Base {
 	 */
 	public function tear_down(): void {
 		global $wp_settings_sections, $wp_settings_fields, $wp_registered_settings;
-		$wp_settings_sections   = array();
-		$wp_settings_fields     = array();
-		$wp_registered_settings = array();
+		$wp_settings_sections   = $this->saved_settings_globals['sections'];
+		$wp_settings_fields     = $this->saved_settings_globals['fields'];
+		$wp_registered_settings = $this->saved_settings_globals['registered'];
 
 		delete_option( 'decker_settings' );
 		wp_set_current_user( 0 );

--- a/tests/unit/admin/DeckerAdminSettingsScreenTest.php
+++ b/tests/unit/admin/DeckerAdminSettingsScreenTest.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Characterization tests for the rendered Decker settings screen.
+ *
+ * These drive the WordPress Settings API — registration on admin_init, then
+ * do_settings_sections() — rather than any render method directly, so the
+ * class that owns each field can change without the tests noticing. What is
+ * pinned is what an administrator actually sees: every field input, in its
+ * section, with its stored value reflected.
+ *
+ * @package Decker
+ */
+
+class DeckerAdminSettingsScreenTest extends Decker_Test_Base {
+
+	/**
+	 * Rendered screen HTML, built once per test.
+	 *
+	 * @var string
+	 */
+	private $html;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		// A known option state so value reflection can be asserted.
+		update_option(
+			'decker_settings',
+			array(
+				'shared_key'           => 'fixed-shared-key-1234',
+				'alert_message'        => 'Maintenance tonight',
+				'alert_color'          => 'warning',
+				'minimum_user_profile' => 'editor',
+				'task_editor_type'     => 'classic',
+				'ignored_users'        => '7,9',
+				'signaling_server'     => 'wss://collab.example.test',
+			)
+		);
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		global $wp_settings_sections, $wp_settings_fields, $wp_registered_settings;
+		$wp_settings_sections   = array();
+		$wp_settings_fields     = array();
+		$wp_registered_settings = array();
+
+		delete_option( 'decker_settings' );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Register the settings as admin_init would, then render the screen.
+	 *
+	 * @return string The rendered sections and fields.
+	 */
+	private function render_screen() {
+		if ( null !== $this->html ) {
+			return $this->html;
+		}
+
+		( new Decker_Admin_Settings() )->settings_init();
+
+		ob_start();
+		do_settings_sections( 'decker' );
+		$this->html = ob_get_clean();
+
+		return $this->html;
+	}
+
+	/**
+	 * Every persisted field is rendered with its decker_settings[...] input name.
+	 *
+	 * @dataProvider field_name_provider
+	 *
+	 * @param string $field Option key the input must carry.
+	 */
+	public function test_every_field_input_is_rendered( $field ) {
+		$this->assertStringContainsString(
+			'name="decker_settings[' . $field . ']"',
+			$this->render_screen(),
+			"The settings screen lost the '{$field}' input."
+		);
+	}
+
+	/**
+	 * The option keys the screen must offer inputs for.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function field_name_provider() {
+		return array(
+			'shared key'          => array( 'shared_key' ),
+			'email notifications' => array( 'allow_email_notifications' ),
+			'collaboration'       => array( 'collaborative_editing' ),
+			'signaling server'    => array( 'signaling_server' ),
+			'minimum profile'     => array( 'minimum_user_profile' ),
+			'alert message'       => array( 'alert_message' ),
+			'alert color'         => array( 'alert_color' ),
+			'ignored users'       => array( 'ignored_users' ),
+			'task editor'         => array( 'task_editor_type' ),
+			'ai enabled'          => array( 'ai_enabled' ),
+			'ai provider'         => array( 'ai_provider' ),
+			'ai api key'          => array( 'ai_api_key' ),
+			'ai model'            => array( 'ai_model' ),
+			'ai prompt'           => array( 'ai_prompt' ),
+		);
+	}
+
+	/**
+	 * Both section intros are rendered.
+	 */
+	public function test_section_intros_are_rendered() {
+		$html = $this->render_screen();
+
+		$this->assertStringContainsString( 'Configure the Decker plugin settings.', $html );
+		$this->assertStringContainsString( 'Configure how Decker improves task descriptions with AI.', $html );
+	}
+
+	/**
+	 * Stored values are reflected back into the rendered controls.
+	 */
+	public function test_stored_values_are_reflected() {
+		$html = $this->render_screen();
+
+		$this->assertStringContainsString( 'value="fixed-shared-key-1234"', $html );
+		$this->assertStringContainsString( 'Maintenance tonight', $html );
+		$this->assertStringContainsString( 'value="7,9"', $html );
+		$this->assertStringContainsString( 'value="wss://collab.example.test"', $html );
+
+		// The stored radio choices come back checked.
+		$this->assertMatchesRegularExpression( '/value="warning"\s+checked=/', $html );
+		$this->assertMatchesRegularExpression( '/value="classic"\s+checked=/', $html );
+	}
+
+	/**
+	 * The destructive clear-all-data control ships with its own nonce.
+	 */
+	public function test_clear_all_data_control_is_nonce_protected() {
+		$html = $this->render_screen();
+
+		$this->assertStringContainsString( 'name="decker_clear_all_data"', $html );
+		$this->assertStringContainsString( 'name="decker_clear_all_data_nonce"', $html );
+	}
+
+	/**
+	 * The browser-local board status toggle renders without a persisted name.
+	 *
+	 * It must not submit as part of decker_settings: the preference lives in
+	 * the browser only.
+	 */
+	public function test_board_status_toggle_is_browser_local() {
+		$html = $this->render_screen();
+
+		$this->assertStringContainsString( 'id="sidebar-board-status-check"', $html );
+		$this->assertStringNotContainsString( 'name="decker_settings[sidebar_board_status]"', $html );
+	}
+
+	/**
+	 * The saved Gemini key is never echoed back into the form.
+	 */
+	public function test_saved_api_key_is_not_echoed() {
+		update_option(
+			'decker_settings',
+			array_merge( get_option( 'decker_settings', array() ), array( 'ai_api_key' => 'sk-super-secret' ) )
+		);
+
+		$html = $this->render_screen();
+
+		$this->assertStringNotContainsString( 'sk-super-secret', $html );
+		$this->assertMatchesRegularExpression(
+			'/name="decker_settings\[ai_api_key\]"[^>]*value=""/',
+			$html,
+			'The API key input must render empty even when a key is stored.'
+		);
+	}
+}

--- a/tests/unit/admin/DeckerAdminSettingsTest.php
+++ b/tests/unit/admin/DeckerAdminSettingsTest.php
@@ -30,7 +30,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 	 */
 	public function test_sidebar_board_status_render_is_browser_local() {
 		ob_start();
-		$this->admin_settings->sidebar_board_status_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'sidebar_board_status' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'id="sidebar-board-status-check"', $output );
@@ -360,7 +360,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		update_option( 'decker_settings', array( 'collaborative_editing' => '0' ) );
 
 		ob_start();
-		$this->admin_settings->collaborative_editing_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'collaborative_editing' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'name="decker_settings[collaborative_editing]"', $output );
@@ -375,7 +375,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		update_option( 'decker_settings', array( 'collaborative_editing' => '1' ) );
 
 		ob_start();
-		$this->admin_settings->collaborative_editing_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'collaborative_editing' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'name="decker_settings[collaborative_editing]"', $output );
@@ -389,7 +389,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		update_option( 'decker_settings', array() );
 
 		ob_start();
-		$this->admin_settings->ai_enabled_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'ai_enabled' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'name="decker_settings[ai_enabled]"', $output );
@@ -403,7 +403,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		update_option( 'decker_settings', array() );
 
 		ob_start();
-		$this->admin_settings->ai_prompt_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'ai_prompt' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'name="decker_settings[ai_prompt]"', $output );
@@ -429,7 +429,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		);
 
 		ob_start();
-		$this->admin_settings->ai_api_key_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'ai_api_key' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'name="decker_settings[ai_api_key]"', $output );
@@ -453,7 +453,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		);
 
 		ob_start();
-		$this->admin_settings->ai_provider_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'ai_provider' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'browser_gemini_nano', $output );
@@ -468,7 +468,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		update_option( 'decker_settings', array() );
 
 		ob_start();
-		$this->admin_settings->signaling_server_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'signaling_server' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'name="decker_settings[signaling_server]"', $output );
@@ -483,7 +483,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 		update_option( 'decker_settings', array( 'signaling_server' => 'wss://custom-server.example.com' ) );
 
 		ob_start();
-		$this->admin_settings->signaling_server_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'signaling_server' ) );
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'value="wss://custom-server.example.com"', $output );
@@ -516,7 +516,7 @@ class DeckerAdminSettingsTest extends WP_UnitTestCase {
 
 		// Start output buffering.
 		ob_start();
-		$this->admin_settings->shared_key_render();
+		( new Decker_Admin_Settings_Fields() )->render( array( 'field' => 'shared_key' ) );
 		$output = ob_get_clean();
 
 		// Retrieve the updated option.

--- a/tests/unit/includes/NotificationHandlerTest.php
+++ b/tests/unit/includes/NotificationHandlerTest.php
@@ -15,6 +15,20 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 	private $notifications;
 
 	/**
+	 * Notification store under test.
+	 *
+	 * @var Decker_Notification_Store
+	 */
+	private $store;
+
+	/**
+	 * Browser-facing notification endpoints under test.
+	 *
+	 * @var Decker_Notification_Ajax
+	 */
+	private $ajax;
+
+	/**
 	 * Test user ID.
 	 *
 	 * @var int
@@ -84,6 +98,8 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 
 		// Initialize the notifications handler.
 		$this->notifications = new Decker_Notification_Handler();
+		$this->store         = new Decker_Notification_Store();
+		$this->ajax          = new Decker_Notification_Ajax( $this->store );
 
 		// Track hooks being fired.
 		add_action( 'decker_user_assigned', array( $this, 'track_hook' ), 10, 2 );
@@ -142,7 +158,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 		$response = array();
 		$data     = array();
 
-		$result = $this->notifications->heartbeat_received( $response, $data, null );
+		$result = $this->ajax->heartbeat_received( $response, $data, null );
 
 		$this->assertEquals( $response, $result, 'Response should not be modified when no notifications exist.' );
 	}
@@ -167,7 +183,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 		$response = array();
 		$data     = array();
 
-		$result = $this->notifications->heartbeat_received( $response, $data, null );
+		$result = $this->ajax->heartbeat_received( $response, $data, null );
 
 		$this->assertArrayHasKey( 'decker_notifications', $result, 'Response should include notifications.' );
 		$this->assertCount( 1, $result['decker_notifications'], 'Response should include exactly one notification.' );
@@ -427,7 +443,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 			'url'     => '#',
 		);
 
-		$this->notifications->add_notification_to_user( $this->test_user, $notification );
+		$this->store->add_notification_to_user( $this->test_user, $notification );
 
 		$all_notifications = get_user_meta( $this->test_user, 'decker_all_notifications', true );
 
@@ -463,7 +479,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 			array( $first_notification, $second_notification )
 		);
 
-		$this->notifications->remove_notification_from_user(
+		$this->store->remove_notification_from_user(
 			$this->test_user,
 			array(
 				'notification_id' => 'notification-1',
@@ -488,7 +504,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 
 		wp_set_current_user( 0 );
 
-		$result = $this->notifications->heartbeat_received( array( 'foo' => 'bar' ), array(), null );
+		$result = $this->ajax->heartbeat_received( array( 'foo' => 'bar' ), array(), null );
 
 		$this->assertSame( array( 'foo' => 'bar' ), $result, 'Anonymous heartbeat should return the response untouched.' );
 		$this->assertNotEmpty(
@@ -510,7 +526,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 			)
 		);
 
-		$result = $this->notifications->heartbeat_received( array(), array(), null );
+		$result = $this->ajax->heartbeat_received( array(), array(), null );
 
 		$items = $result['decker_notifications'];
 
@@ -537,7 +553,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 			array( array( 'type' => 'task_created' ) )
 		);
 
-		$result = $this->notifications->heartbeat_received( array( 'existing' => 1 ), array(), null );
+		$result = $this->ajax->heartbeat_received( array( 'existing' => 1 ), array(), null );
 
 		$this->assertSame( 1, $result['existing'], 'Existing response key should be preserved.' );
 		$this->assertCount( 1, $result['decker_notifications'], 'Should format exactly one notification.' );
@@ -565,7 +581,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 
 		ob_start();
 		try {
-			$this->notifications->ajax_get_decker_notifications();
+			$this->ajax->ajax_get_decker_notifications();
 		} catch ( WPDieException $e ) {
 			$e->getMessage();
 		}
@@ -596,7 +612,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 
 		ob_start();
 		try {
-			$this->notifications->ajax_get_decker_notifications();
+			$this->ajax->ajax_get_decker_notifications();
 		} catch ( WPDieException $e ) {
 			$e->getMessage();
 		}
@@ -618,7 +634,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 
 		ob_start();
 		try {
-			$this->notifications->ajax_get_decker_notifications();
+			$this->ajax->ajax_get_decker_notifications();
 		} catch ( WPDieException $e ) {
 			$e->getMessage();
 		}
@@ -931,7 +947,7 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 			'url'     => '#',
 		);
 
-		$this->notifications->add_notification_to_user( $this->test_user, $notification );
+		$this->store->add_notification_to_user( $this->test_user, $notification );
 
 		$all      = get_user_meta( $this->test_user, 'decker_all_notifications', true );
 		$expected = md5(

--- a/tests/unit/includes/NotificationHandlerTest.php
+++ b/tests/unit/includes/NotificationHandlerTest.php
@@ -96,10 +96,12 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 			)
 		);
 
-		// Initialize the notifications handler.
-		$this->notifications = new Decker_Notification_Handler();
+		// Initialize the notifications stack. The store and ajax instances are
+		// injected into the handler so the tests drive the same objects the
+		// handler persists through, and the Heartbeat/AJAX hooks register once.
 		$this->store         = new Decker_Notification_Store();
 		$this->ajax          = new Decker_Notification_Ajax( $this->store );
+		$this->notifications = new Decker_Notification_Handler( $this->store, $this->ajax );
 
 		// Track hooks being fired.
 		add_action( 'decker_user_assigned', array( $this, 'track_hook' ), 10, 2 );
@@ -565,6 +567,11 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 
 	/**
 	 * Locks the CURRENT ascending sort + front slice for the AJAX endpoint.
+	 *
+	 * This documents a bug rather than endorsing it: the endpoint's comments
+	 * promise newest-first but the code returns oldest-first and drops the
+	 * newest entries once over the cap. Tracked in issue #293 — when that is
+	 * fixed, this test must flip with it.
 	 */
 	public function test_ajax_get_notifications_returns_oldest_first_and_caps_at_15() {
 		$notifications = array();


### PR DESCRIPTION
Third pass on the PHPMD `codesize` alerts, following #290 and #291. Takes the count from **20 to 14**.

Runtime behaviour is unchanged. As in #291, some public methods change owner; the full table is in *Compatibility* below and in `docs/development.md`.

## What moved

| Class | Warnings cleared | New owners |
|---|---|---|
| `Decker_Admin_Settings` | ExcessiveClassComplexity (96 → ~18), TooManyMethods (35 → 9), TooManyPublicMethods (22 → 6) | `Decker_Admin_Settings_Fields`, `Decker_Admin_Settings_Validator` |
| `Decker_Notification_Handler` | ExcessiveClassComplexity (112 → ~45), TooManyPublicMethods (14 → 6) | `Decker_Notification_Store`, `Decker_Notification_Ajax` |
| `Decker_Events` | TooManyPublicMethods (12 → 9) | `Decker_Event_Admin_Screen` |

**6 cleared, 0 added**, verified by diffing the full `phpmd` run before and after, keyed on file + rule.

## The settings screen: why a dispatcher instead of moving methods

`Decker_Admin_Settings` was three jobs in one class — drawing every field, validating every submission, coordinating the screen. But sixteen render callbacks were public only so the Settings API could call them, and moving them as-is would have recreated `TooManyPublicMethods` on the new class.

Instead `Decker_Admin_Settings_Fields` exposes a **single public `render()` dispatcher**, and `add_settings_field()` hands it the field id through `$args`. WordPress still reaches every field, adding a field no longer adds public surface, and the render bodies moved verbatim with their visibility flipped to private.

The validators moved behind one public `validate( $input, $current_values )`. `settings_validate()` stays as the registered sanitize callback and delegates — which is why the **53 existing validation tests pass unchanged**: they exercise the same public entry point they always did.

## The notification handler: why three classes, not two

Complexity 112. A two-way split (events vs. browser) fails arithmetic: the browser-facing half alone sums to ~65, still over the 50 threshold — it would have moved the warning, not cleared it. So:

- `Decker_Notification_Store` — both user-meta lists (the capped panel list and the pending list Heartbeat drains), the client payload mapping, the icon tables.
- `Decker_Notification_Ajax` — the Heartbeat filters and four AJAX endpoints, delegating every read and write to the store.
- `Decker_Notification_Handler` — the five task-event handlers and their e-mails, persisting through the store.

Method bodies moved verbatim; the only edits are the `$this->store->` delegation prefix and the constant's new home.

## Compatibility

Same policy as #291 (internal reorganisation, recorded, no shims — agreed there and documented in `docs/development.md`, which now carries this round's rows too):

| Was | Is now |
|---|---|
| `Decker_Admin_Settings::*_render()` (16) + 2 section callbacks | `Decker_Admin_Settings_Fields` |
| `Decker_Notification_Handler::add/remove_notification_to_user()` | `Decker_Notification_Store` |
| `Decker_Notification_Handler::MAX_NOTIFICATIONS` (public constant) | `Decker_Notification_Store::MAX_NOTIFICATIONS` |
| `Decker_Notification_Handler::heartbeat_received()` / `modify_heartbeat_settings()` / 4 × `ajax_*()` | `Decker_Notification_Ajax` |
| `Decker_Events::hide_visibility_options()` / `add_custom_columns()` / `render_custom_columns()` | `Decker_Event_Admin_Screen` |

The render callbacks additionally became private behind the dispatcher — unhooking a single settings field by callback name was never possible through public API anyway (`remove_settings_field` doesn't exist; fields are removed via the global), so nothing that worked before stops working silently.

## Tests

19 added: `DeckerAdminSettingsScreenTest` drives the Settings API itself — registration on `admin_init`, then `do_settings_sections()` — so field ownership stays an implementation detail. It pins every field input by name, section intros, stored-value reflection, and two guarantees worth keeping loud: **the saved Gemini API key is never echoed back into the form**, and the browser-local board-status toggle never submits as part of `decker_settings`. Written and green *before* the refactor.

Existing tests that called moved members directly (render callbacks, heartbeat, AJAX, store) now target the owning class; the 33 notification tests and 53 settings-validation tests pass otherwise unchanged.

## Out of scope

The 14 remaining: `Decker_Tasks` (6 warnings — needs a genuine rewrite), `Task` model (2), and single complexity warnings on `Decker_Calendar`, `TaskManager`, `Decker_Kb`, `Decker_Email_To_Post`, `Decker_Demo_Data` and `Decker_Events` (whose excess is the meta-saving code pinned by a 19-call-site characterization test — its own PR).

## Verification

- **PHPMD**: 14 results on the PR ref, confirmed by the code-scanning API, against 20 on `main`.
- **CI**: all checks green, including `lint_and_test`.
- **Full local suite**: **903 tests, 10155 assertions, 0 failures.**
- **Mutation-checked**: the new screen test fails when a field is dropped from registration (2 failures) and when the stored Gemini key is echoed back into the form's `value` attribute (1 failure). Both mutants were verified to have applied before drawing conclusions.

### The "pre-existing failures" were never code failures

Worth its own note: #290 and #291 documented ~16 failures in Calendar, DemoData, Sidebar and TaskManager as pre-existing suite-interaction failures, identical on `main` and on each branch. While verifying this round, the test database got corrupted (my doing — a concurrent phpunit run during the backgrounded suite) and had to be reset with `wp-env clean tests`. On the freshly reset environment the **entire suite passes** — those failures were accumulated state in the shared test environment, not code. If `make test` shows them again, reset the tests environment before debugging anything.


## Review follow-ups (`edf3664`)

- **Settings globals**: the screen test's `tear_down()` wiped `$wp_settings_sections` / `$wp_settings_fields` / `$wp_registered_settings` outright, which could erase other tests' registrations. It now snapshots the three in `set_up()` and restores them exactly. The full `tests/unit/admin/` directory (92 tests) passes together, which is where order-dependence would have surfaced.
- **Double hook registration**: the notification tests built a second `Decker_Notification_Ajax` beside the handler's internal one, registering the Heartbeat/AJAX hooks twice and exercising a parallel store. The handler now takes both collaborators as optional constructor arguments (production behaviour unchanged when omitted) and the tests inject the pair they drive — so the assertions run against the very instances the handler persists through.
- **Compatibility table**: the moved `MAX_NOTIFICATIONS` public constant is now listed (here and in `docs/development.md`).
- **Ordering bug**: review caught that `ajax_get_decker_notifications()` promises newest-first but returns oldest-first and drops the newest once over the cap. Pre-existing (the code moved verbatim) and now tracked in **#293**; the test that locks the current behaviour states explicitly that it documents the bug rather than endorsing it. Not fixed here — this PR stays behaviour-preserving.
