### PR TITLE
Reduce PHPMD codesize alerts from 10 to 8

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -86,6 +86,9 @@ the new one. None of these changed behaviour; only their owner changed.
 | `Decker_Demo_Data` task/comment seeding and randomness helpers | `Decker_Demo_Tasks`, `Decker_Demo_Randomizer` |
 | `Decker_Calendar::handle_ical_request()` / `add_ical_endpoint()` and access checks | `Decker_Calendar_Ical_Feed` |
 | `Decker_Calendar::get_cached_ical()` / `flush_cache_*()` | `Decker_Calendar_Cache` |
+| `Decker_Kb::save_article()` and the write path | `Decker_Kb_Article_Writer` |
+| `Decker_Kb::reorder_articles()` and sibling renumbering | `Decker_Kb_Reorder` |
+| `TaskManager` "for today" query bodies (public entry points stay as delegators) | `Decker_Task_Today_Query`, `Decker_Task_Date_Relations` |
 | `Decker_Public::enqueue_scripts()` body | `Decker_Public_Assets` |
 
 Note that unhooking one of these by name fails **silently** rather than fatally:

--- a/includes/class-decker.php
+++ b/includes/class-decker.php
@@ -200,6 +200,8 @@ class Decker {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-decker-taxonomy-manager.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-boardmanager.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-labelmanager.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-decker-task-date-relations.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-decker-task-today-query.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/models/class-taskmanager.php';
 	}
 

--- a/includes/class-decker.php
+++ b/includes/class-decker.php
@@ -149,6 +149,8 @@ class Decker {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-event-meta-box.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-events.php';
 
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb-reorder.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb-article-writer.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb-revisions.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-kb.php';
 	}

--- a/includes/custom-post-types/class-decker-kb-article-writer.php
+++ b/includes/custom-post-types/class-decker-kb-article-writer.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Creates and updates Knowledge Base articles over REST.
+ *
+ * Owns the save endpoint's whole write path: resolving whether the request
+ * targets an existing article, building the post data, assigning board and
+ * labels, and renumbering siblings when the article moved between parents.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Kb_Article_Writer
+ */
+class Decker_Kb_Article_Writer {
+
+	/**
+	 * Sibling renumbering used after a parent change.
+	 *
+	 * @var Decker_Kb_Reorder
+	 */
+	private $reorder;
+
+	/**
+	 * Take the reorder collaborator.
+	 *
+	 * @param Decker_Kb_Reorder $reorder Sibling renumbering.
+	 */
+	public function __construct( Decker_Kb_Reorder $reorder ) {
+		$this->reorder = $reorder;
+	}
+
+	/**
+	 * Save or update KB article
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function save_article( $request ) {
+		$params = $request->get_params();
+
+		$desired_position = isset( $params['menu_order'] ) ? max( 0, intval( $params['menu_order'] ) ) : null;
+
+		// Validate that board is provided only on create (no ID).
+		if ( empty( $params['id'] ) && empty( $params['board'] ) ) {
+			return Decker_Kb::error_response( __( 'Board is required', 'decker' ) );
+		}
+
+		// Look up the existing post (with IDOR guards) when updating.
+		$existing_post = $this->get_existing_article( $params );
+		if ( $existing_post instanceof WP_REST_Response ) {
+			return $existing_post;
+		}
+
+		$old_parent_id = $existing_post ? intval( $existing_post->post_parent ) : null;
+
+		$post_data = $this->build_article_post_data( $params, $existing_post );
+
+		$post_id = wp_insert_post( $post_data );
+
+		if ( is_wp_error( $post_id ) ) {
+			return Decker_Kb::error_response( $post_id->get_error_message() );
+		}
+
+		// Assign labels and board; a non-null return is a terminal error response.
+		$terms_error = $this->assign_article_terms( $post_id, $params );
+		if ( $terms_error ) {
+			return $terms_error;
+		}
+
+		$new_parent_id = intval( $post_data['post_parent'] );
+		$this->maybe_reorder_after_save( $params, $post_id, $old_parent_id, $new_parent_id, $desired_position );
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'message' => __( 'Article saved successfully', 'decker' ),
+				'id'     => $post_id,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Look up the existing KB article for an update request.
+	 *
+	 * Returns null when creating (no ID), the WP_Post when the update target is a
+	 * valid editable KB article, or a WP_REST_Response error when the IDOR guards
+	 * (missing/non-KB post or insufficient capability) reject the request.
+	 *
+	 * @param array $params Request params.
+	 * @return WP_Post|WP_REST_Response|null
+	 */
+	private function get_existing_article( array $params ) {
+		if ( empty( $params['id'] ) ) {
+			return null;
+		}
+
+		$post_id       = intval( $params['id'] );
+		$existing_post = get_post( $post_id );
+
+		// Ensure the target post exists and is actually a KB article.
+		if ( ! $existing_post || 'decker_kb' !== $existing_post->post_type ) {
+			return Decker_Kb::error_response( __( 'Article not found', 'decker' ), 404 );
+		}
+
+		// Require per-post edit capability for updates.
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return Decker_Kb::error_response( __( 'You do not have permission to edit this article', 'decker' ), 403 );
+		}
+
+		return $existing_post;
+	}
+
+	/**
+	 * Build the wp_insert_post() array for a save_article() request.
+	 *
+	 * Always sets post_parent and menu_order (provided param -> existing value -> 0)
+	 * so the caller can read post_parent unconditionally.
+	 *
+	 * @param array        $params        Request params.
+	 * @param WP_Post|null $existing_post Existing post on update, null on create.
+	 * @return array
+	 */
+	private function build_article_post_data( array $params, $existing_post ) {
+		$post_data = array(
+			'post_type'    => 'decker_kb',
+			'post_status'  => 'publish',
+		);
+
+		// Title and content always allowed.
+		if ( isset( $params['title'] ) ) {
+			$post_data['post_title'] = sanitize_text_field( $params['title'] );
+		}
+		if ( isset( $params['content'] ) ) {
+			$post_data['post_content'] = wp_kses_post( $params['content'] );
+		}
+
+		if ( ! empty( $params['id'] ) ) {
+			$post_data['ID'] = intval( $params['id'] );
+		}
+
+		// Parent and order: only set if provided. If not, preserve existing values on update.
+		if ( isset( $params['parent_id'] ) ) {
+			$post_data['post_parent'] = intval( $params['parent_id'] );
+		} elseif ( $existing_post ) {
+			$post_data['post_parent'] = $existing_post->post_parent;
+		} else {
+			$post_data['post_parent'] = 0;
+		}
+
+		if ( isset( $params['menu_order'] ) ) {
+			$post_data['menu_order'] = intval( $params['menu_order'] );
+		} elseif ( $existing_post ) {
+			$post_data['menu_order'] = $existing_post->menu_order;
+		} else {
+			$post_data['menu_order'] = 0;
+		}
+
+		return $post_data;
+	}
+
+	/**
+	 * Assign labels and board taxonomy terms for a saved article.
+	 *
+	 * Returns null on success, or a WP_REST_Response error when an invalid board
+	 * is supplied on create (the freshly created post is hard-deleted first).
+	 *
+	 * @param int   $post_id Saved post ID.
+	 * @param array $params  Request params.
+	 * @return WP_REST_Response|null
+	 */
+	private function assign_article_terms( $post_id, array $params ) {
+		// Handle labels: only update if provided; otherwise keep.
+		if ( isset( $params['labels'] ) && is_array( $params['labels'] ) ) {
+			wp_set_object_terms( $post_id, array_map( 'intval', $params['labels'] ), 'decker_label' );
+		}
+
+		// Handle board: update only if provided; otherwise keep current for updates.
+		if ( isset( $params['board'] ) ) {
+			$board_id = intval( $params['board'] );
+			if ( $board_id > 0 ) {
+				wp_set_object_terms( $post_id, array( $board_id ), 'decker_board' );
+			} elseif ( empty( $params['id'] ) ) {
+				// If creating and invalid board, reject.
+				wp_delete_post( $post_id, true );
+				return Decker_Kb::error_response( __( 'Invalid board ID', 'decker' ) );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Recalculate siblings after a save when order or parent changed in the request.
+	 *
+	 * @param array    $params           Request params.
+	 * @param int      $post_id          Saved post ID.
+	 * @param int|null $old_parent_id    Parent before the save (null on create).
+	 * @param int      $new_parent_id    Parent after the save.
+	 * @param int|null $desired_position Desired index (null appends).
+	 */
+	private function maybe_reorder_after_save( array $params, $post_id, $old_parent_id, $new_parent_id, $desired_position ) {
+		$parent_changed = ( null !== $old_parent_id && $old_parent_id !== $new_parent_id );
+
+		if ( ! isset( $params['menu_order'] ) && ! $parent_changed ) {
+			return;
+		}
+
+		$this->reorder->recalculate_siblings_with_position( $new_parent_id, $post_id, $desired_position );
+		if ( $parent_changed ) {
+			$this->reorder->recalculate_siblings( $old_parent_id );
+		}
+	}
+}

--- a/includes/custom-post-types/class-decker-kb-reorder.php
+++ b/includes/custom-post-types/class-decker-kb-reorder.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Keeps Knowledge Base articles in order inside their parent.
+ *
+ * Articles are ordered by menu_order per parent. This class owns the REST
+ * reorder endpoint used by drag-and-drop, and the sibling renumbering the
+ * article writer needs after a save moves an article between parents.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Kb_Reorder
+ */
+class Decker_Kb_Reorder {
+
+	/**
+	 * REST callback to handle drag-and-drop reordering.
+	 *
+	 * Expects: moved_id, new_parent_id, new_order (array of IDs), old_parent_id, old_order (array of IDs).
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return WP_REST_Response
+	 */
+	public function reorder_articles( $request ) {
+		$args = $this->parse_reorder_request( $request );
+
+		if ( ! $args['moved_id'] ) {
+			return Decker_Kb::error_response( __( 'Invalid moved ID.', 'decker' ) );
+		}
+
+		// Update parent for moved item.
+		wp_update_post(
+			array(
+				'ID'          => $args['moved_id'],
+				'post_parent' => $args['new_parent_id'],
+			)
+		);
+
+		// Apply new order for target siblings.
+		$this->apply_explicit_order( $args['new_parent_id'], $args['new_order'] );
+
+		// Recalculate old siblings if provided.
+		$this->reorder_previous_parent( $args['old_parent_id'], $args['old_order'] );
+
+		return new WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * Normalize the reorder request params into typed values.
+	 *
+	 * The old_parent_id value stays nullable: null means "not provided" (skip
+	 * old-side recalculation), while 0 means the root parent.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return array {
+	 *     @type int      $moved_id      Moved post ID (0 default).
+	 *     @type int      $new_parent_id Target parent ID (0 default).
+	 *     @type int|null $old_parent_id Previous parent ID (null when absent).
+	 *     @type int[]    $new_order     Ordered IDs for the target parent.
+	 *     @type int[]    $old_order     Ordered IDs for the previous parent.
+	 * }
+	 */
+	private function parse_reorder_request( $request ) {
+		$params = $request->get_params();
+
+		return array(
+			'moved_id'      => isset( $params['moved_id'] ) ? intval( $params['moved_id'] ) : 0,
+			'new_parent_id' => isset( $params['new_parent_id'] ) ? intval( $params['new_parent_id'] ) : 0,
+			'old_parent_id' => isset( $params['old_parent_id'] ) ? intval( $params['old_parent_id'] ) : null,
+			'new_order'     => isset( $params['new_order'] ) && is_array( $params['new_order'] ) ? array_map( 'intval', $params['new_order'] ) : array(),
+			'old_order'     => isset( $params['old_order'] ) && is_array( $params['old_order'] ) ? array_map( 'intval', $params['old_order'] ) : array(),
+		);
+	}
+
+	/**
+	 * Recalculate the previous parent's siblings after a move.
+	 *
+	 * No-op when the old parent was not provided (null sentinel). Applies the
+	 * explicit order when supplied, otherwise resequences the remaining children.
+	 *
+	 * @param int|null $old_parent_id Previous parent ID (null skips).
+	 * @param array    $old_order     Ordered IDs for the previous parent.
+	 */
+	private function reorder_previous_parent( $old_parent_id, array $old_order ) {
+		if ( null === $old_parent_id ) {
+			return;
+		}
+
+		if ( $old_order ) {
+			$this->apply_explicit_order( $old_parent_id, $old_order );
+		} else {
+			$this->recalculate_siblings( $old_parent_id );
+		}
+	}
+
+	/**
+	 * Recalculate sequential menu_order for all children of a parent.
+	 *
+	 * @param int $parent_id Parent post ID.
+	 */
+	public function recalculate_siblings( $parent_id ) {
+		$children = get_children(
+			array(
+				'post_type'      => 'decker_kb',
+				'post_parent'    => intval( $parent_id ),
+				'orderby'        => 'menu_order',
+				'order'          => 'ASC',
+				'numberposts'    => -1,
+			)
+		);
+		$index = 0;
+		foreach ( $children as $child ) {
+			wp_update_post(
+				array(
+					'ID'         => $child->ID,
+					'menu_order' => $index++,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Recalculate siblings placing the given post at desired position.
+	 *
+	 * @param int      $parent_id Parent ID.
+	 * @param int      $post_id   Post ID to position.
+	 * @param int|null $position  Desired index (0-based). If null, just recalc sequentially.
+	 */
+	public function recalculate_siblings_with_position( $parent_id, $post_id, $position ) {
+		$children = get_children(
+			array(
+				'post_type'      => 'decker_kb',
+				'post_parent'    => intval( $parent_id ),
+				'orderby'        => 'menu_order',
+				'order'          => 'ASC',
+				'numberposts'    => -1,
+			)
+		);
+
+		$ids = array();
+		foreach ( $children as $child ) {
+			if ( intval( $child->ID ) !== intval( $post_id ) ) {
+				$ids[] = intval( $child->ID );
+			}
+		}
+		if ( null === $position || $position < 0 ) {
+			$ids[] = intval( $post_id );
+		} else {
+			$position = min( $position, count( $ids ) );
+			array_splice( $ids, $position, 0, array( intval( $post_id ) ) );
+		}
+
+		$this->apply_explicit_order( $parent_id, $ids );
+	}
+
+	/**
+	 * Apply explicit ordering to children list by IDs.
+	 *
+	 * @param int   $parent_id Parent post ID.
+	 * @param array $ordered_ids Ordered IDs of children.
+	 */
+	private function apply_explicit_order( $parent_id, $ordered_ids ) {
+		$index = 0;
+		foreach ( $ordered_ids as $cid ) {
+			wp_update_post(
+				array(
+					'ID'          => intval( $cid ),
+					'post_parent' => intval( $parent_id ),
+					'menu_order'  => $index++,
+				)
+			);
+		}
+	}
+}

--- a/includes/custom-post-types/class-decker-kb.php
+++ b/includes/custom-post-types/class-decker-kb.php
@@ -15,9 +15,26 @@
 class Decker_Kb {
 
 	/**
+	 * Sibling renumbering and the reorder endpoint.
+	 *
+	 * @var Decker_Kb_Reorder
+	 */
+	private $reorder;
+
+	/**
+	 * The article write path.
+	 *
+	 * @var Decker_Kb_Article_Writer
+	 */
+	private $writer;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
+		$this->reorder = new Decker_Kb_Reorder();
+		$this->writer  = new Decker_Kb_Article_Writer( $this->reorder );
+
 		$this->define_hooks();
 	}
 
@@ -48,7 +65,7 @@ class Decker_Kb {
 			array(
 				array(
 					'methods'             => 'POST',
-					'callback'            => array( $this, 'save_article' ),
+					'callback'            => array( $this->writer, 'save_article' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
 				),
 				array(
@@ -66,7 +83,7 @@ class Decker_Kb {
 			array(
 				array(
 					'methods'             => 'POST',
-					'callback'            => array( $this, 'reorder_articles' ),
+					'callback'            => array( $this->reorder, 'reorder_articles' ),
 					'permission_callback' => array( $this, 'check_permissions' ),
 				),
 			)
@@ -124,196 +141,13 @@ class Decker_Kb {
 	}
 
 	/**
-	 * Save or update KB article
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response
-	 */
-	public function save_article( $request ) {
-		$params = $request->get_params();
-
-		$desired_position = isset( $params['menu_order'] ) ? max( 0, intval( $params['menu_order'] ) ) : null;
-
-		// Validate that board is provided only on create (no ID).
-		if ( empty( $params['id'] ) && empty( $params['board'] ) ) {
-			return $this->error_response( __( 'Board is required', 'decker' ) );
-		}
-
-		// Look up the existing post (with IDOR guards) when updating.
-		$existing_post = $this->get_existing_article( $params );
-		if ( $existing_post instanceof WP_REST_Response ) {
-			return $existing_post;
-		}
-
-		$old_parent_id = $existing_post ? intval( $existing_post->post_parent ) : null;
-
-		$post_data = $this->build_article_post_data( $params, $existing_post );
-
-		$post_id = wp_insert_post( $post_data );
-
-		if ( is_wp_error( $post_id ) ) {
-			return $this->error_response( $post_id->get_error_message() );
-		}
-
-		// Assign labels and board; a non-null return is a terminal error response.
-		$terms_error = $this->assign_article_terms( $post_id, $params );
-		if ( $terms_error ) {
-			return $terms_error;
-		}
-
-		$new_parent_id = intval( $post_data['post_parent'] );
-		$this->maybe_reorder_after_save( $params, $post_id, $old_parent_id, $new_parent_id, $desired_position );
-
-		return new WP_REST_Response(
-			array(
-				'success' => true,
-				'message' => __( 'Article saved successfully', 'decker' ),
-				'id'     => $post_id,
-			),
-			200
-		);
-	}
-
-	/**
-	 * Look up the existing KB article for an update request.
-	 *
-	 * Returns null when creating (no ID), the WP_Post when the update target is a
-	 * valid editable KB article, or a WP_REST_Response error when the IDOR guards
-	 * (missing/non-KB post or insufficient capability) reject the request.
-	 *
-	 * @param array $params Request params.
-	 * @return WP_Post|WP_REST_Response|null
-	 */
-	private function get_existing_article( array $params ) {
-		if ( empty( $params['id'] ) ) {
-			return null;
-		}
-
-		$post_id       = intval( $params['id'] );
-		$existing_post = get_post( $post_id );
-
-		// Ensure the target post exists and is actually a KB article.
-		if ( ! $existing_post || 'decker_kb' !== $existing_post->post_type ) {
-			return $this->error_response( __( 'Article not found', 'decker' ), 404 );
-		}
-
-		// Require per-post edit capability for updates.
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return $this->error_response( __( 'You do not have permission to edit this article', 'decker' ), 403 );
-		}
-
-		return $existing_post;
-	}
-
-	/**
-	 * Build the wp_insert_post() array for a save_article() request.
-	 *
-	 * Always sets post_parent and menu_order (provided param -> existing value -> 0)
-	 * so the caller can read post_parent unconditionally.
-	 *
-	 * @param array        $params        Request params.
-	 * @param WP_Post|null $existing_post Existing post on update, null on create.
-	 * @return array
-	 */
-	private function build_article_post_data( array $params, $existing_post ) {
-		$post_data = array(
-			'post_type'    => 'decker_kb',
-			'post_status'  => 'publish',
-		);
-
-		// Title and content always allowed.
-		if ( isset( $params['title'] ) ) {
-			$post_data['post_title'] = sanitize_text_field( $params['title'] );
-		}
-		if ( isset( $params['content'] ) ) {
-			$post_data['post_content'] = wp_kses_post( $params['content'] );
-		}
-
-		if ( ! empty( $params['id'] ) ) {
-			$post_data['ID'] = intval( $params['id'] );
-		}
-
-		// Parent and order: only set if provided. If not, preserve existing values on update.
-		if ( isset( $params['parent_id'] ) ) {
-			$post_data['post_parent'] = intval( $params['parent_id'] );
-		} elseif ( $existing_post ) {
-			$post_data['post_parent'] = $existing_post->post_parent;
-		} else {
-			$post_data['post_parent'] = 0;
-		}
-
-		if ( isset( $params['menu_order'] ) ) {
-			$post_data['menu_order'] = intval( $params['menu_order'] );
-		} elseif ( $existing_post ) {
-			$post_data['menu_order'] = $existing_post->menu_order;
-		} else {
-			$post_data['menu_order'] = 0;
-		}
-
-		return $post_data;
-	}
-
-	/**
-	 * Assign labels and board taxonomy terms for a saved article.
-	 *
-	 * Returns null on success, or a WP_REST_Response error when an invalid board
-	 * is supplied on create (the freshly created post is hard-deleted first).
-	 *
-	 * @param int   $post_id Saved post ID.
-	 * @param array $params  Request params.
-	 * @return WP_REST_Response|null
-	 */
-	private function assign_article_terms( $post_id, array $params ) {
-		// Handle labels: only update if provided; otherwise keep.
-		if ( isset( $params['labels'] ) && is_array( $params['labels'] ) ) {
-			wp_set_object_terms( $post_id, array_map( 'intval', $params['labels'] ), 'decker_label' );
-		}
-
-		// Handle board: update only if provided; otherwise keep current for updates.
-		if ( isset( $params['board'] ) ) {
-			$board_id = intval( $params['board'] );
-			if ( $board_id > 0 ) {
-				wp_set_object_terms( $post_id, array( $board_id ), 'decker_board' );
-			} elseif ( empty( $params['id'] ) ) {
-				// If creating and invalid board, reject.
-				wp_delete_post( $post_id, true );
-				return $this->error_response( __( 'Invalid board ID', 'decker' ) );
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Recalculate siblings after a save when order or parent changed in the request.
-	 *
-	 * @param array    $params           Request params.
-	 * @param int      $post_id          Saved post ID.
-	 * @param int|null $old_parent_id    Parent before the save (null on create).
-	 * @param int      $new_parent_id    Parent after the save.
-	 * @param int|null $desired_position Desired index (null appends).
-	 */
-	private function maybe_reorder_after_save( array $params, $post_id, $old_parent_id, $new_parent_id, $desired_position ) {
-		$parent_changed = ( null !== $old_parent_id && $old_parent_id !== $new_parent_id );
-
-		if ( ! isset( $params['menu_order'] ) && ! $parent_changed ) {
-			return;
-		}
-
-		$this->recalculate_siblings_with_position( $new_parent_id, $post_id, $desired_position );
-		if ( $parent_changed ) {
-			$this->recalculate_siblings( $old_parent_id );
-		}
-	}
-
-	/**
 	 * Build a standard error WP_REST_Response.
 	 *
 	 * @param string $message Human-readable error message.
 	 * @param int    $status  HTTP status code.
 	 * @return WP_REST_Response
 	 */
-	private function error_response( $message, $status = 400 ) {
+	public static function error_response( $message, $status = 400 ) {
 		return new WP_REST_Response(
 			array(
 				'success' => false,
@@ -321,165 +155,6 @@ class Decker_Kb {
 			),
 			$status
 		);
-	}
-
-	/**
-	 * REST callback to handle drag-and-drop reordering.
-	 *
-	 * Expects: moved_id, new_parent_id, new_order (array of IDs), old_parent_id, old_order (array of IDs).
-	 *
-	 * @param WP_REST_Request $request The request.
-	 * @return WP_REST_Response
-	 */
-	public function reorder_articles( $request ) {
-		$args = $this->parse_reorder_request( $request );
-
-		if ( ! $args['moved_id'] ) {
-			return $this->error_response( __( 'Invalid moved ID.', 'decker' ) );
-		}
-
-		// Update parent for moved item.
-		wp_update_post(
-			array(
-				'ID'          => $args['moved_id'],
-				'post_parent' => $args['new_parent_id'],
-			)
-		);
-
-		// Apply new order for target siblings.
-		$this->apply_explicit_order( $args['new_parent_id'], $args['new_order'] );
-
-		// Recalculate old siblings if provided.
-		$this->reorder_previous_parent( $args['old_parent_id'], $args['old_order'] );
-
-		return new WP_REST_Response( array( 'success' => true ), 200 );
-	}
-
-	/**
-	 * Normalize the reorder request params into typed values.
-	 *
-	 * The old_parent_id value stays nullable: null means "not provided" (skip
-	 * old-side recalculation), while 0 means the root parent.
-	 *
-	 * @param WP_REST_Request $request The request.
-	 * @return array {
-	 *     @type int      $moved_id      Moved post ID (0 default).
-	 *     @type int      $new_parent_id Target parent ID (0 default).
-	 *     @type int|null $old_parent_id Previous parent ID (null when absent).
-	 *     @type int[]    $new_order     Ordered IDs for the target parent.
-	 *     @type int[]    $old_order     Ordered IDs for the previous parent.
-	 * }
-	 */
-	private function parse_reorder_request( $request ) {
-		$params = $request->get_params();
-
-		return array(
-			'moved_id'      => isset( $params['moved_id'] ) ? intval( $params['moved_id'] ) : 0,
-			'new_parent_id' => isset( $params['new_parent_id'] ) ? intval( $params['new_parent_id'] ) : 0,
-			'old_parent_id' => isset( $params['old_parent_id'] ) ? intval( $params['old_parent_id'] ) : null,
-			'new_order'     => isset( $params['new_order'] ) && is_array( $params['new_order'] ) ? array_map( 'intval', $params['new_order'] ) : array(),
-			'old_order'     => isset( $params['old_order'] ) && is_array( $params['old_order'] ) ? array_map( 'intval', $params['old_order'] ) : array(),
-		);
-	}
-
-	/**
-	 * Recalculate the previous parent's siblings after a move.
-	 *
-	 * No-op when the old parent was not provided (null sentinel). Applies the
-	 * explicit order when supplied, otherwise resequences the remaining children.
-	 *
-	 * @param int|null $old_parent_id Previous parent ID (null skips).
-	 * @param array    $old_order     Ordered IDs for the previous parent.
-	 */
-	private function reorder_previous_parent( $old_parent_id, array $old_order ) {
-		if ( null === $old_parent_id ) {
-			return;
-		}
-
-		if ( $old_order ) {
-			$this->apply_explicit_order( $old_parent_id, $old_order );
-		} else {
-			$this->recalculate_siblings( $old_parent_id );
-		}
-	}
-
-	/**
-	 * Recalculate sequential menu_order for all children of a parent.
-	 *
-	 * @param int $parent_id Parent post ID.
-	 */
-	private function recalculate_siblings( $parent_id ) {
-		$children = get_children(
-			array(
-				'post_type'      => 'decker_kb',
-				'post_parent'    => intval( $parent_id ),
-				'orderby'        => 'menu_order',
-				'order'          => 'ASC',
-				'numberposts'    => -1,
-			)
-		);
-		$index = 0;
-		foreach ( $children as $child ) {
-			wp_update_post(
-				array(
-					'ID'         => $child->ID,
-					'menu_order' => $index++,
-				)
-			);
-		}
-	}
-
-	/**
-	 * Recalculate siblings placing the given post at desired position.
-	 *
-	 * @param int      $parent_id Parent ID.
-	 * @param int      $post_id   Post ID to position.
-	 * @param int|null $position  Desired index (0-based). If null, just recalc sequentially.
-	 */
-	private function recalculate_siblings_with_position( $parent_id, $post_id, $position ) {
-		$children = get_children(
-			array(
-				'post_type'      => 'decker_kb',
-				'post_parent'    => intval( $parent_id ),
-				'orderby'        => 'menu_order',
-				'order'          => 'ASC',
-				'numberposts'    => -1,
-			)
-		);
-
-		$ids = array();
-		foreach ( $children as $child ) {
-			if ( intval( $child->ID ) !== intval( $post_id ) ) {
-				$ids[] = intval( $child->ID );
-			}
-		}
-		if ( null === $position || $position < 0 ) {
-			$ids[] = intval( $post_id );
-		} else {
-			$position = min( $position, count( $ids ) );
-			array_splice( $ids, $position, 0, array( intval( $post_id ) ) );
-		}
-
-		$this->apply_explicit_order( $parent_id, $ids );
-	}
-
-	/**
-	 * Apply explicit ordering to children list by IDs.
-	 *
-	 * @param int   $parent_id Parent post ID.
-	 * @param array $ordered_ids Ordered IDs of children.
-	 */
-	private function apply_explicit_order( $parent_id, $ordered_ids ) {
-		$index = 0;
-		foreach ( $ordered_ids as $cid ) {
-			wp_update_post(
-				array(
-					'ID'          => intval( $cid ),
-					'post_parent' => intval( $parent_id ),
-					'menu_order'  => $index++,
-				)
-			);
-		}
 	}
 
 	/**

--- a/includes/models/class-decker-task-date-relations.php
+++ b/includes/models/class-decker-task-date-relations.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Record-level helpers for the per-user "for today" date relations.
+ *
+ * A task stores its _user_date_relations meta as a list of user/date pairs.
+ * These helpers judge single records and fold over relation lists; they hold
+ * no query logic and touch no database themselves beyond what a caller hands
+ * them.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Task_Date_Relations
+ */
+class Decker_Task_Date_Relations {
+
+	/**
+	 * Checks if a user has a relation within a date range.
+	 *
+	 * @param array    $relations  Array of user-date relations.
+	 * @param int      $user_id    The ID of the user.
+	 * @param DateTime $start_date Start date for filtering.
+	 * @param DateTime $end_date   End date for filtering.
+	 * @return bool Whether the user has a relation in the date range.
+	 */
+	public function has_relation_in_date_range( array $relations, int $user_id, DateTime $start_date, DateTime $end_date ): bool {
+		foreach ( $relations as $relation ) {
+			if ( ! isset( $relation['user_id'], $relation['date'] ) || $relation['user_id'] != $user_id ) {
+				continue;
+			}
+
+			$relation_date = DateTime::createFromFormat( 'Y-m-d', $relation['date'] );
+
+			if ( $relation_date && $relation_date >= $start_date && $relation_date <= $end_date ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Updates the latest date based on user-date relations.
+	 *
+	 * @param array     $relations Array of user-date relations.
+	 * @param int       $user_id The ID of the user.
+	 * @param DateTime  $today Today's date.
+	 * @param DateTime  $min_date Minimum date to consider.
+	 * @param ?DateTime $latest_date Current latest date.
+	 * @return ?DateTime Updated latest date.
+	 */
+	public function update_latest_date( array $relations, int $user_id, DateTime $today, DateTime $min_date, ?DateTime $latest_date ): ?DateTime {
+		foreach ( $relations as $relation ) {
+			if ( ! isset( $relation['user_id'], $relation['date'] ) || $relation['user_id'] != $user_id ) {
+				continue;
+			}
+
+			$relation_date = DateTime::createFromFormat( 'Y-m-d', $relation['date'] );
+
+			// Skip dates that are today or in the future, and limit to max_days_back.
+			if ( ! $relation_date || $relation_date >= $today || $relation_date < $min_date ) {
+				continue;
+			}
+
+			if ( ! $latest_date || $relation_date > $latest_date ) {
+				$latest_date = $relation_date;
+			}
+		}
+
+		return $latest_date;
+	}
+
+	/**
+	 * Process user date relations and collect valid dates.
+	 *
+	 * @param array    $relations Array of user-date relations.
+	 * @param int      $user_id The ID of the user.
+	 * @param DateTime $today Today's date.
+	 * @param DateTime $min_date Minimum date to consider.
+	 * @param string   $today_str Today's date as string.
+	 * @param array    $dates Array to collect valid dates.
+	 */
+	public function process_user_date_relations( array $relations, int $user_id, DateTime $today, DateTime $min_date, string $today_str, array &$dates ): void {
+		foreach ( $relations as $relation ) {
+			if ( ! $this->is_valid_user_relation( $relation, $user_id ) ) {
+				continue;
+			}
+
+			$date_str = $relation['date'];
+
+			if ( $this->is_valid_date_for_collection( $date_str, $today, $min_date, $today_str ) && ! in_array( $date_str, $dates ) ) {
+				$dates[] = $date_str;
+			}
+		}
+	}
+
+	/**
+	 * Check if a relation is valid for the specified user.
+	 *
+	 * @param array $relation The relation to check.
+	 * @param int   $user_id The user ID to check against.
+	 * @return bool Whether the relation is valid.
+	 */
+	public function is_valid_user_relation( array $relation, int $user_id ): bool {
+		return isset( $relation['user_id'], $relation['date'] ) && $relation['user_id'] == $user_id;
+	}
+
+	/**
+	 * Check if a date is valid for collection.
+	 *
+	 * @param string   $date_str The date string to check.
+	 * @param DateTime $today Today's date.
+	 * @param DateTime $min_date Minimum date to consider.
+	 * @param string   $today_str Today's date as string.
+	 * @return bool Whether the date is valid for collection.
+	 */
+	public function is_valid_date_for_collection( string $date_str, DateTime $today, DateTime $min_date, string $today_str ): bool {
+		$relation_date = DateTime::createFromFormat( 'Y-m-d', $date_str );
+
+		// Skip dates that are today or in the future, and limit to max_days_back.
+		if ( ! $relation_date || $date_str == $today_str || $relation_date >= $today || $relation_date < $min_date ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/includes/models/class-decker-task-today-query.php
+++ b/includes/models/class-decker-task-today-query.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * Queries the tasks a user marked "for today".
+ *
+ * Owns the date-relation side of the task queries: which tasks carry a
+ * relation for a user today or in a recent window, and which dates a user
+ * has marked at all. Record-level judgments are delegated to
+ * Decker_Task_Date_Relations; TaskManager keeps thin public delegators so
+ * its callers are unaffected.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Task_Today_Query
+ */
+class Decker_Task_Today_Query {
+
+	/**
+	 * Record-level relation helpers.
+	 *
+	 * @var Decker_Task_Date_Relations
+	 */
+	private $relations;
+
+	/**
+	 * Take the relation helpers.
+	 *
+	 * @param Decker_Task_Date_Relations $relations Record-level relation helpers.
+	 */
+	public function __construct( Decker_Task_Date_Relations $relations ) {
+		$this->relations = $relations;
+	}
+
+	/**
+	 * Checks if the current user has tasks assigned for today.
+	 *
+	 * @return bool True if the user has tasks for today, false otherwise.
+	 */
+	public function has_user_today_tasks(): bool {
+		$user_id = get_current_user_id();
+		$args    = array(
+			'post_type'   => 'decker_task',
+			'post_status' => 'publish',
+			'numberposts' => -1,
+			'fields'      => 'ids', // Only retrieve IDs for performance optimization.
+			'meta_query'  => array(
+				'relation' => 'AND',
+				array(
+					'key'     => 'assigned_users',
+					'value'   => $user_id,
+					'compare' => 'LIKE',
+				),
+				array(
+					'key'     => '_user_date_relations',
+					'compare' => 'EXISTS', // Only include tasks where the meta key exists.
+				),
+			),
+		);
+
+		// Important! Here we are using direct post_id retrieval for optimization.
+		$post_ids = get_posts( $args );
+
+		   // Optimization: Load metadata into cache.
+		if ( ! empty( $post_ids ) ) {
+			update_meta_cache( 'post', $post_ids );
+		}
+
+		$today    = ( new DateTime() )->format( 'Y-m-d' );
+
+		// Additional filtering: Check tasks that are not truly assigned to the specified user.
+		// Filtering serialized data can be risky and unreliable due to how data is stored.
+		foreach ( $post_ids as $post_id ) {
+			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
+
+			if ( is_array( $user_date_relations ) ) {
+				foreach ( $user_date_relations as $relation ) {
+					if (
+						isset( $relation['user_id'], $relation['date'] ) && $relation['user_id'] == $user_id && $relation['date'] == $today
+					) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retrieves tasks assigned to a specific user that have been marked between today and a specified number of previous days.
+	 *
+	 * The function fetches tasks assigned to the given user and filters them based on user-date relations.
+	 * It returns tasks where the user has a relation date between the start date (today minus $days) and today.
+	 *
+	 * @param int       $user_id The ID of the user.
+	 * @param int       $days Number of days to look back from today. Pass 0 to get tasks for today only.
+	 * @param bool      $show_hidden_task Switch to show/not show hidden task. Default is true.
+	 * @param ?DateTime $specific_date Optional specific date to load tasks from. If provided, $days is ignored.
+	 * @return Task[] List of Task objects within the specified time range.
+	 */
+	public function get_user_tasks_marked_for_today_for_previous_days( int $user_id, int $days, bool $show_hidden_task = true, ?DateTime $specific_date = null ): array {
+		// Get task post IDs that match the criteria.
+		$post_ids = $this->get_task_post_ids_for_user( $user_id, $show_hidden_task );
+
+		if ( empty( $post_ids ) ) {
+			return array();
+		}
+
+		// Calculate date range.
+		$date_range = $this->calculate_date_range( $days, $specific_date );
+
+		// Filter tasks by date relations.
+		return $this->filter_tasks_by_date_relations( $post_ids, $user_id, $date_range['start'], $date_range['end'] );
+	}
+
+	/**
+	 * Finds the latest date when a user marked tasks.
+	 *
+	 * @param int $user_id The ID of the user.
+	 * @param int $max_days_back Maximum number of days to look back (default: 7).
+	 * @return ?DateTime The latest date found or null if no dates found.
+	 */
+	public function get_latest_user_task_date( int $user_id, int $max_days_back = 7 ): ?DateTime {
+		// Get task post IDs that match the criteria.
+		$post_ids = $this->get_task_post_ids_for_user( $user_id, true );
+
+		if ( empty( $post_ids ) ) {
+			return null;
+		}
+
+		// Get date constraints.
+		$date_constraints = $this->get_date_constraints( $max_days_back );
+
+		// Find the latest date.
+		return $this->find_latest_date_in_relations( $post_ids, $user_id, $date_constraints['today'], $date_constraints['min_date'] );
+	}
+
+	/**
+	 * Gets available dates when a user marked tasks in the past.
+	 *
+	 * @param int $user_id The ID of the user.
+	 * @param int $max_days_back Maximum number of days to look back (default: 7).
+	 * @return array Array of dates in Y-m-d format.
+	 */
+	public function get_user_task_dates( int $user_id, int $max_days_back = 7 ): array {
+		$args = array(
+			'post_type'   => 'decker_task',
+			'post_status' => 'publish',
+			'numberposts' => -1,
+			'fields'      => 'ids',
+			'meta_query'  => array(
+				'relation' => 'AND',
+				array(
+					'key'     => 'assigned_users',
+					'value'   => $user_id,
+					'compare' => 'LIKE',
+				),
+				array(
+					'key'     => '_user_date_relations',
+					'compare' => 'EXISTS',
+				),
+			),
+		);
+
+		$post_ids = get_posts( $args );
+
+		if ( empty( $post_ids ) ) {
+			return array();
+		}
+
+		update_meta_cache( 'post', $post_ids );
+
+		$today = new DateTime();
+		$min_date = ( clone $today )->modify( "-$max_days_back days" );
+		$today_str = $today->format( 'Y-m-d' );
+
+		$dates = $this->extract_valid_dates_from_posts( $post_ids, $user_id, $today, $min_date, $today_str );
+
+		// Sort dates in descending order (newest first).
+		usort(
+			$dates,
+			function ( $a, $b ) {
+				return strcmp( $b, $a );
+			}
+		);
+
+		return $dates;
+	}
+
+	/**
+	 * Gets task post IDs for a specific user.
+	 *
+	 * @param int  $user_id The ID of the user.
+	 * @param bool $show_hidden_task Whether to show hidden tasks.
+	 * @return array Array of post IDs.
+	 */
+	private function get_task_post_ids_for_user( int $user_id, bool $show_hidden_task ): array {
+		$args = array(
+			'post_type'   => 'decker_task',
+			'post_status' => 'publish',
+			'numberposts' => -1,
+			'fields'      => 'ids', // Only retrieve IDs for performance optimization.
+			'meta_query' => array(
+				'relation' => 'AND',
+				array(
+					'key'     => 'assigned_users',
+					'value'   => $user_id,
+					'compare' => 'LIKE',
+				),
+				array(
+					'key'     => '_user_date_relations',
+					'compare' => 'EXISTS',
+				),
+			),
+		);
+
+		// Not showing hidden task if the parameter show_hidden_task is false.
+		if ( ! $show_hidden_task ) {
+			$args['meta_query'][] = array(
+				'key'     => 'hidden',
+				'value'   => '1',
+				'compare' => '!=',
+			);
+		}
+
+		// Important! Here we are using direct post_id retrieval for optimization.
+		$post_ids = get_posts( $args );
+
+		   // Optimization: Load metadata into cache.
+		if ( ! empty( $post_ids ) ) {
+			update_meta_cache( 'post', $post_ids );
+		}
+
+		return $post_ids;
+	}
+
+	/**
+	 * Calculates the date range for task filtering.
+	 *
+	 * @param int       $days Number of days to look back.
+	 * @param ?DateTime $specific_date Optional specific date.
+	 * @return array Array with start and end dates.
+	 */
+	private function calculate_date_range( int $days, ?DateTime $specific_date = null ): array {
+		$today = ( new DateTime() )->setTime( 23, 59 );
+
+		if ( $specific_date ) {
+			// If a specific date is provided, use it as both start and end date.
+			$start_date = clone $specific_date;
+			$start_date->setTime( 0, 0 );
+			$end_date = clone $specific_date;
+			$end_date->setTime( 23, 59 );
+		} else {
+			// Otherwise use the days parameter.
+			$start_date = ( new DateTime() )->setTime( 0, 0 )->modify( "-$days days" );
+			$end_date = $today;
+		}
+
+		return array(
+			'start' => $start_date,
+			'end'   => $end_date,
+		);
+	}
+
+	/**
+	 * Filters tasks by date relations.
+	 *
+	 * @param array    $post_ids   Array of post IDs.
+	 * @param int      $user_id    The ID of the user.
+	 * @param DateTime $start_date Start date for filtering.
+	 * @param DateTime $end_date   End date for filtering.
+	 * @return array Array of Task objects.
+	 */
+	private function filter_tasks_by_date_relations( array $post_ids, int $user_id, DateTime $start_date, DateTime $end_date ): array {
+		$tasks = array();
+
+		foreach ( $post_ids as $post_id ) {
+			// Retrieve the assigned users for the task.
+			$assigned_users = get_post_meta( $post_id, 'assigned_users', true );
+
+			if ( ! is_array( $assigned_users ) || ! in_array( $user_id, $assigned_users ) ) {
+				continue;
+			}
+
+			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
+
+			if ( ! is_array( $user_date_relations ) ) {
+				continue;
+			}
+
+			if ( $this->relations->has_relation_in_date_range( $user_date_relations, $user_id, $start_date, $end_date ) ) {
+				$tasks[] = new Task( $post_id );
+			}
+		}
+
+		return $tasks;
+	}
+
+	/**
+	 * Gets date constraints for filtering.
+	 *
+	 * @param int $max_days_back Maximum number of days to look back.
+	 * @return array Array with today and min_date.
+	 */
+	private function get_date_constraints( int $max_days_back ): array {
+		$today = new DateTime();
+		$min_date = ( clone $today )->modify( "-$max_days_back days" );
+
+		return array(
+			'today' => $today,
+			'min_date' => $min_date,
+		);
+	}
+
+	/**
+	 * Finds the latest date in user-date relations.
+	 *
+	 * @param array    $post_ids Array of post IDs.
+	 * @param int      $user_id The ID of the user.
+	 * @param DateTime $today Today's date.
+	 * @param DateTime $min_date Minimum date to consider.
+	 * @return ?DateTime The latest date found or null if no dates found.
+	 */
+	private function find_latest_date_in_relations( array $post_ids, int $user_id, DateTime $today, DateTime $min_date ): ?DateTime {
+		$latest_date = null;
+
+		foreach ( $post_ids as $post_id ) {
+			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
+
+			if ( ! is_array( $user_date_relations ) ) {
+				continue;
+			}
+
+			$latest_date = $this->relations->update_latest_date( $user_date_relations, $user_id, $today, $min_date, $latest_date );
+		}
+
+		return $latest_date;
+	}
+
+	/**
+	 * Extract valid dates from post metadata.
+	 *
+	 * @param array    $post_ids Array of post IDs.
+	 * @param int      $user_id The ID of the user.
+	 * @param DateTime $today Today's date.
+	 * @param DateTime $min_date Minimum date to consider.
+	 * @param string   $today_str Today's date as string.
+	 * @return array Array of valid dates in Y-m-d format.
+	 */
+	private function extract_valid_dates_from_posts( array $post_ids, int $user_id, DateTime $today, DateTime $min_date, string $today_str ): array {
+		$dates = array();
+
+		foreach ( $post_ids as $post_id ) {
+			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
+
+			if ( ! is_array( $user_date_relations ) ) {
+				continue;
+			}
+
+			$this->relations->process_user_date_relations( $user_date_relations, $user_id, $today, $min_date, $today_str, $dates );
+		}
+
+		return $dates;
+	}
+}

--- a/includes/models/class-taskmanager.php
+++ b/includes/models/class-taskmanager.php
@@ -179,8 +179,6 @@ class TaskManager {
 		return $this->get_tasks( $args );
 	}
 
-
-
 	/**
 	 * Retrieves tasks by Board (term relation).
 	 *
@@ -290,62 +288,6 @@ class TaskManager {
 		return $counts;
 	}
 
-
-	/**
-	 * Checks if the current user has tasks assigned for today.
-	 *
-	 * @return bool True if the user has tasks for today, false otherwise.
-	 */
-	public function has_user_today_tasks(): bool {
-		$user_id = get_current_user_id();
-		$args    = array(
-			'post_type'   => 'decker_task',
-			'post_status' => 'publish',
-			'numberposts' => -1,
-			'fields'      => 'ids', // Only retrieve IDs for performance optimization.
-			'meta_query'  => array(
-				'relation' => 'AND',
-				array(
-					'key'     => 'assigned_users',
-					'value'   => $user_id,
-					'compare' => 'LIKE',
-				),
-				array(
-					'key'     => '_user_date_relations',
-					'compare' => 'EXISTS', // Only include tasks where the meta key exists.
-				),
-			),
-		);
-
-		// Important! Here we are using direct post_id retrieval for optimization.
-		$post_ids = get_posts( $args );
-
-		   // Optimization: Load metadata into cache.
-		if ( ! empty( $post_ids ) ) {
-			update_meta_cache( 'post', $post_ids );
-		}
-
-		$today    = ( new DateTime() )->format( 'Y-m-d' );
-
-		// Additional filtering: Check tasks that are not truly assigned to the specified user.
-		// Filtering serialized data can be risky and unreliable due to how data is stored.
-		foreach ( $post_ids as $post_id ) {
-			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
-
-			if ( is_array( $user_date_relations ) ) {
-				foreach ( $user_date_relations as $relation ) {
-					if (
-						isset( $relation['user_id'], $relation['date'] ) && $relation['user_id'] == $user_id && $relation['date'] == $today
-					) {
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
-	}
-
 	/**
 	 * Retrieves tasks with an upcoming due date within a specified date range.
 	 *
@@ -392,390 +334,56 @@ class TaskManager {
 	}
 
 	/**
-	 * Retrieves tasks assigned to a specific user that have been marked between today and a specified number of previous days.
+	 * The "for today" query collaborator.
 	 *
-	 * The function fetches tasks assigned to the given user and filters them based on user-date relations.
-	 * It returns tasks where the user has a relation date between the start date (today minus $days) and today.
+	 * @return Decker_Task_Today_Query
+	 */
+	private function today_query(): Decker_Task_Today_Query {
+		return new Decker_Task_Today_Query( new Decker_Task_Date_Relations() );
+	}
+
+	/**
+	 * Whether the current user marked any task for today.
 	 *
-	 * @param int       $user_id The ID of the user.
-	 * @param int       $days Number of days to look back from today. Pass 0 to get tasks for today only.
-	 * @param bool      $show_hidden_task Switch to show/not show hidden task. Default is true.
-	 * @param ?DateTime $specific_date Optional specific date to load tasks from. If provided, $days is ignored.
-	 * @return Task[] List of Task objects within the specified time range.
+	 * @return bool
+	 */
+	public function has_user_today_tasks(): bool {
+		return $this->today_query()->has_user_today_tasks();
+	}
+
+	/**
+	 * Tasks a user marked between today and a number of previous days.
+	 *
+	 * @param int       $user_id          The ID of the user.
+	 * @param int       $days             Number of days to look back from today. Pass 0 for today only.
+	 * @param bool      $show_hidden_task Switch to show/not show hidden tasks. Default true.
+	 * @param ?DateTime $specific_date    Optional specific date to load tasks from; $days is then ignored.
+	 * @return Task[] List of Task objects within the range.
 	 */
 	public function get_user_tasks_marked_for_today_for_previous_days( int $user_id, int $days, bool $show_hidden_task = true, ?DateTime $specific_date = null ): array {
-		// Get task post IDs that match the criteria.
-		$post_ids = $this->get_task_post_ids_for_user( $user_id, $show_hidden_task );
-
-		if ( empty( $post_ids ) ) {
-			return array();
-		}
-
-		// Calculate date range.
-		$date_range = $this->calculate_date_range( $days, $specific_date );
-
-		// Filter tasks by date relations.
-		return $this->filter_tasks_by_date_relations( $post_ids, $user_id, $date_range['start'], $date_range['end'] );
+		return $this->today_query()->get_user_tasks_marked_for_today_for_previous_days( $user_id, $days, $show_hidden_task, $specific_date );
 	}
 
 	/**
-	 * Gets task post IDs for a specific user.
+	 * Latest date on which a user marked tasks.
 	 *
-	 * @param int  $user_id The ID of the user.
-	 * @param bool $show_hidden_task Whether to show hidden tasks.
-	 * @return array Array of post IDs.
-	 */
-	private function get_task_post_ids_for_user( int $user_id, bool $show_hidden_task ): array {
-		$args = array(
-			'post_type'   => 'decker_task',
-			'post_status' => 'publish',
-			'numberposts' => -1,
-			'fields'      => 'ids', // Only retrieve IDs for performance optimization.
-			'meta_query' => array(
-				'relation' => 'AND',
-				array(
-					'key'     => 'assigned_users',
-					'value'   => $user_id,
-					'compare' => 'LIKE',
-				),
-				array(
-					'key'     => '_user_date_relations',
-					'compare' => 'EXISTS',
-				),
-			),
-		);
-
-		// Not showing hidden task if the parameter show_hidden_task is false.
-		if ( ! $show_hidden_task ) {
-			$args['meta_query'][] = array(
-				'key'     => 'hidden',
-				'value'   => '1',
-				'compare' => '!=',
-			);
-		}
-
-		// Important! Here we are using direct post_id retrieval for optimization.
-		$post_ids = get_posts( $args );
-
-		   // Optimization: Load metadata into cache.
-		if ( ! empty( $post_ids ) ) {
-			update_meta_cache( 'post', $post_ids );
-		}
-
-		return $post_ids;
-	}
-
-	/**
-	 * Calculates the date range for task filtering.
-	 *
-	 * @param int       $days Number of days to look back.
-	 * @param ?DateTime $specific_date Optional specific date.
-	 * @return array Array with start and end dates.
-	 */
-	private function calculate_date_range( int $days, ?DateTime $specific_date = null ): array {
-		$today = ( new DateTime() )->setTime( 23, 59 );
-
-		if ( $specific_date ) {
-			// If a specific date is provided, use it as both start and end date.
-			$start_date = clone $specific_date;
-			$start_date->setTime( 0, 0 );
-			$end_date = clone $specific_date;
-			$end_date->setTime( 23, 59 );
-		} else {
-			// Otherwise use the days parameter.
-			$start_date = ( new DateTime() )->setTime( 0, 0 )->modify( "-$days days" );
-			$end_date = $today;
-		}
-
-		return array(
-			'start' => $start_date,
-			'end'   => $end_date,
-		);
-	}
-
-	/**
-	 * Filters tasks by date relations.
-	 *
-	 * @param array    $post_ids   Array of post IDs.
-	 * @param int      $user_id    The ID of the user.
-	 * @param DateTime $start_date Start date for filtering.
-	 * @param DateTime $end_date   End date for filtering.
-	 * @return array Array of Task objects.
-	 */
-	private function filter_tasks_by_date_relations( array $post_ids, int $user_id, DateTime $start_date, DateTime $end_date ): array {
-		$tasks = array();
-
-		foreach ( $post_ids as $post_id ) {
-			// Retrieve the assigned users for the task.
-			$assigned_users = get_post_meta( $post_id, 'assigned_users', true );
-
-			if ( ! is_array( $assigned_users ) || ! in_array( $user_id, $assigned_users ) ) {
-				continue;
-			}
-
-			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
-
-			if ( ! is_array( $user_date_relations ) ) {
-				continue;
-			}
-
-			if ( $this->has_relation_in_date_range( $user_date_relations, $user_id, $start_date, $end_date ) ) {
-				$tasks[] = new Task( $post_id );
-			}
-		}
-
-		return $tasks;
-	}
-
-	/**
-	 * Checks if a user has a relation within a date range.
-	 *
-	 * @param array    $relations  Array of user-date relations.
-	 * @param int      $user_id    The ID of the user.
-	 * @param DateTime $start_date Start date for filtering.
-	 * @param DateTime $end_date   End date for filtering.
-	 * @return bool Whether the user has a relation in the date range.
-	 */
-	private function has_relation_in_date_range( array $relations, int $user_id, DateTime $start_date, DateTime $end_date ): bool {
-		foreach ( $relations as $relation ) {
-			if ( ! isset( $relation['user_id'], $relation['date'] ) || $relation['user_id'] != $user_id ) {
-				continue;
-			}
-
-			$relation_date = DateTime::createFromFormat( 'Y-m-d', $relation['date'] );
-
-			if ( $relation_date && $relation_date >= $start_date && $relation_date <= $end_date ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Finds the latest date when a user marked tasks.
-	 *
-	 * @param int $user_id The ID of the user.
-	 * @param int $max_days_back Maximum number of days to look back (default: 7).
-	 * @return ?DateTime The latest date found or null if no dates found.
+	 * @param int $user_id       The ID of the user.
+	 * @param int $max_days_back Maximum number of days to look back (default 7).
+	 * @return ?DateTime The latest date found, or null.
 	 */
 	public function get_latest_user_task_date( int $user_id, int $max_days_back = 7 ): ?DateTime {
-		// Get task post IDs that match the criteria.
-		$post_ids = $this->get_task_post_ids_for_user( $user_id, true );
-
-		if ( empty( $post_ids ) ) {
-			return null;
-		}
-
-		// Get date constraints.
-		$date_constraints = $this->get_date_constraints( $max_days_back );
-
-		// Find the latest date.
-		return $this->find_latest_date_in_relations( $post_ids, $user_id, $date_constraints['today'], $date_constraints['min_date'] );
+		return $this->today_query()->get_latest_user_task_date( $user_id, $max_days_back );
 	}
 
 	/**
-	 * Gets date constraints for filtering.
+	 * Dates on which a user marked tasks, most recent first.
 	 *
-	 * @param int $max_days_back Maximum number of days to look back.
-	 * @return array Array with today and min_date.
-	 */
-	private function get_date_constraints( int $max_days_back ): array {
-		$today = new DateTime();
-		$min_date = ( clone $today )->modify( "-$max_days_back days" );
-
-		return array(
-			'today' => $today,
-			'min_date' => $min_date,
-		);
-	}
-
-	/**
-	 * Finds the latest date in user-date relations.
-	 *
-	 * @param array    $post_ids Array of post IDs.
-	 * @param int      $user_id The ID of the user.
-	 * @param DateTime $today Today's date.
-	 * @param DateTime $min_date Minimum date to consider.
-	 * @return ?DateTime The latest date found or null if no dates found.
-	 */
-	private function find_latest_date_in_relations( array $post_ids, int $user_id, DateTime $today, DateTime $min_date ): ?DateTime {
-		$latest_date = null;
-
-		foreach ( $post_ids as $post_id ) {
-			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
-
-			if ( ! is_array( $user_date_relations ) ) {
-				continue;
-			}
-
-			$latest_date = $this->update_latest_date( $user_date_relations, $user_id, $today, $min_date, $latest_date );
-		}
-
-		return $latest_date;
-	}
-
-	/**
-	 * Updates the latest date based on user-date relations.
-	 *
-	 * @param array     $relations Array of user-date relations.
-	 * @param int       $user_id The ID of the user.
-	 * @param DateTime  $today Today's date.
-	 * @param DateTime  $min_date Minimum date to consider.
-	 * @param ?DateTime $latest_date Current latest date.
-	 * @return ?DateTime Updated latest date.
-	 */
-	private function update_latest_date( array $relations, int $user_id, DateTime $today, DateTime $min_date, ?DateTime $latest_date ): ?DateTime {
-		foreach ( $relations as $relation ) {
-			if ( ! isset( $relation['user_id'], $relation['date'] ) || $relation['user_id'] != $user_id ) {
-				continue;
-			}
-
-			$relation_date = DateTime::createFromFormat( 'Y-m-d', $relation['date'] );
-
-			// Skip dates that are today or in the future, and limit to max_days_back.
-			if ( ! $relation_date || $relation_date >= $today || $relation_date < $min_date ) {
-				continue;
-			}
-
-			if ( ! $latest_date || $relation_date > $latest_date ) {
-				$latest_date = $relation_date;
-			}
-		}
-
-		return $latest_date;
-	}
-
-	/**
-	 * Gets available dates when a user marked tasks in the past.
-	 *
-	 * @param int $user_id The ID of the user.
-	 * @param int $max_days_back Maximum number of days to look back (default: 7).
-	 * @return array Array of dates in Y-m-d format.
+	 * @param int $user_id       The ID of the user.
+	 * @param int $max_days_back Maximum number of days to look back (default 7).
+	 * @return array The dates found.
 	 */
 	public function get_user_task_dates( int $user_id, int $max_days_back = 7 ): array {
-		$args = array(
-			'post_type'   => 'decker_task',
-			'post_status' => 'publish',
-			'numberposts' => -1,
-			'fields'      => 'ids',
-			'meta_query'  => array(
-				'relation' => 'AND',
-				array(
-					'key'     => 'assigned_users',
-					'value'   => $user_id,
-					'compare' => 'LIKE',
-				),
-				array(
-					'key'     => '_user_date_relations',
-					'compare' => 'EXISTS',
-				),
-			),
-		);
-
-		$post_ids = get_posts( $args );
-
-		if ( empty( $post_ids ) ) {
-			return array();
-		}
-
-		update_meta_cache( 'post', $post_ids );
-
-		$today = new DateTime();
-		$min_date = ( clone $today )->modify( "-$max_days_back days" );
-		$today_str = $today->format( 'Y-m-d' );
-
-		$dates = $this->extract_valid_dates_from_posts( $post_ids, $user_id, $today, $min_date, $today_str );
-
-		// Sort dates in descending order (newest first).
-		usort(
-			$dates,
-			function ( $a, $b ) {
-				return strcmp( $b, $a );
-			}
-		);
-
-		return $dates;
+		return $this->today_query()->get_user_task_dates( $user_id, $max_days_back );
 	}
 
-	/**
-	 * Extract valid dates from post metadata.
-	 *
-	 * @param array    $post_ids Array of post IDs.
-	 * @param int      $user_id The ID of the user.
-	 * @param DateTime $today Today's date.
-	 * @param DateTime $min_date Minimum date to consider.
-	 * @param string   $today_str Today's date as string.
-	 * @return array Array of valid dates in Y-m-d format.
-	 */
-	private function extract_valid_dates_from_posts( array $post_ids, int $user_id, DateTime $today, DateTime $min_date, string $today_str ): array {
-		$dates = array();
-
-		foreach ( $post_ids as $post_id ) {
-			$user_date_relations = get_post_meta( $post_id, '_user_date_relations', true );
-
-			if ( ! is_array( $user_date_relations ) ) {
-				continue;
-			}
-
-			$this->process_user_date_relations( $user_date_relations, $user_id, $today, $min_date, $today_str, $dates );
-		}
-
-		return $dates;
-	}
-
-	/**
-	 * Process user date relations and collect valid dates.
-	 *
-	 * @param array    $relations Array of user-date relations.
-	 * @param int      $user_id The ID of the user.
-	 * @param DateTime $today Today's date.
-	 * @param DateTime $min_date Minimum date to consider.
-	 * @param string   $today_str Today's date as string.
-	 * @param array    $dates Array to collect valid dates.
-	 */
-	private function process_user_date_relations( array $relations, int $user_id, DateTime $today, DateTime $min_date, string $today_str, array &$dates ): void {
-		foreach ( $relations as $relation ) {
-			if ( ! $this->is_valid_user_relation( $relation, $user_id ) ) {
-				continue;
-			}
-
-			$date_str = $relation['date'];
-
-			if ( $this->is_valid_date_for_collection( $date_str, $today, $min_date, $today_str ) && ! in_array( $date_str, $dates ) ) {
-				$dates[] = $date_str;
-			}
-		}
-	}
-
-	/**
-	 * Check if a relation is valid for the specified user.
-	 *
-	 * @param array $relation The relation to check.
-	 * @param int   $user_id The user ID to check against.
-	 * @return bool Whether the relation is valid.
-	 */
-	private function is_valid_user_relation( array $relation, int $user_id ): bool {
-		return isset( $relation['user_id'], $relation['date'] ) && $relation['user_id'] == $user_id;
-	}
-
-	/**
-	 * Check if a date is valid for collection.
-	 *
-	 * @param string   $date_str The date string to check.
-	 * @param DateTime $today Today's date.
-	 * @param DateTime $min_date Minimum date to consider.
-	 * @param string   $today_str Today's date as string.
-	 * @return bool Whether the date is valid for collection.
-	 */
-	private function is_valid_date_for_collection( string $date_str, DateTime $today, DateTime $min_date, string $today_str ): bool {
-		$relation_date = DateTime::createFromFormat( 'Y-m-d', $date_str );
-
-		// Skip dates that are today or in the future, and limit to max_days_back.
-		if ( ! $relation_date || $date_str == $today_str || $relation_date >= $today || $relation_date < $min_date ) {
-			return false;
-		}
-
-		return true;
-	}
 }

--- a/includes/models/class-taskmanager.php
+++ b/includes/models/class-taskmanager.php
@@ -385,5 +385,4 @@ class TaskManager {
 	public function get_user_task_dates( int $user_id, int $max_days_back = 7 ): array {
 		return $this->today_query()->get_user_task_dates( $user_id, $max_days_back );
 	}
-
 }


### PR DESCRIPTION
Fifth pass on the PHPMD `codesize` alerts, following #290–#292 and #294. Takes the count from **10 to 8**.

Runtime behaviour is unchanged. Same compatibility policy as every round since #291: internal reorganisation, recorded in `docs/development.md`, no shims — public entry points that outside code actually calls stay put as delegators.

## What moved

| Class | Complexity | New owners |
|---|---|---|
| `Decker_Kb` | 93 → ~39 | `Decker_Kb_Article_Writer`, `Decker_Kb_Reorder` |
| `TaskManager` | 87 → ~31 | `Decker_Task_Today_Query`, `Decker_Task_Date_Relations` |

**2 cleared, 0 added**, verified by diffing the full `phpmd` run before and after, keyed on file + rule. All four new classes come out clean.

## Why each target needed two collaborators, not one

Both had the same arithmetic problem: the extractable cluster was itself over the 50 threshold, so a single collaborator would have moved the warning instead of clearing it.

- **Kb**: the write path (~32) and the reorder machinery (~22) sum past 50 together. They also change for different reasons — one when the article form changes, the other when the tree ordering rules do. The writer takes the reorder class in its constructor because a save that moves an article between parents must renumber both sets of siblings. `error_response()` becomes a public static on `Decker_Kb`, shared by all three REST controllers rather than duplicated.
- **TaskManager**: the "for today" cluster summed to ~60. The seam is record vs. query: `Decker_Task_Date_Relations` judges single `_user_date_relations` entries and folds over relation lists; `Decker_Task_Today_Query` owns the meta queries and date windows and delegates each record decision.

## Caller impact: none

- The Kb REST routes now register the collaborator instances as callbacks; permissions stay on `Decker_Kb`. Tests drive the routes, not the methods, so all 42 pass unchanged.
- `TaskManager` keeps its four public entry points (`has_user_today_tasks`, `get_user_tasks_marked_for_today_for_previous_days`, `get_latest_user_task_date`, `get_user_task_dates`) as thin delegators — they are called from ten places across the templates. The 36 task-manager and today-quick-action tests pass unchanged.

## Out of scope

The 8 remaining are exactly the hard tail: `Decker_Tasks` (6 warnings, ~4000 lines — the genuine rewrite) and the `Task` model (complexity 120 and 16 public fields — reshaping it touches every template that reads those fields). Neither fits a safe mechanical round; both deserve a designed decomposition with its own plan.

## Verification

- **Full local suite: 903 tests, 10187 assertions, 0 failures** — serial, fresh environment.
- phpcs clean on all changed files; POT diff is line references only (0 msgids added or removed).
