### PR TITLE
Decompose Decker_Tasks 5/7: admin list and chrome

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -99,6 +99,8 @@ the new one. None of these changed behaviour; only their owner changed.
 | `Decker_Tasks` order/stack engine (`update_task_stack_and_order()`, `handle_fix_order()`, `reorder_tasks_in_stack()`, `get_new_task_order()`) | `Decker_Task_Order` |
 | `Decker_Tasks` order hook reactions (post-data filter, board/stack term changes) | `Decker_Task_Order_Hooks` |
 | `Decker_Tasks` edit-screen meta boxes (`add_meta_boxes()` and the eight display/render methods) | `Decker_Task_Meta_Boxes` |
+| `Decker_Tasks` admin list table (columns, sorting, taxonomy/status filters) | `Decker_Task_Admin_List` |
+| `Decker_Tasks` edit-screen chrome (visibility/menu-order/permalink hiding, publish box title, Gutenberg disable, Add New removal) | `Decker_Task_Admin_Chrome` |
 | `Decker_Public::enqueue_scripts()` body | `Decker_Public_Assets` |
 
 Note that unhooking one of these by name fails **silently** rather than fatally:

--- a/docs/superpowers/plans/2026-07-29-decker-tasks-pr-e-admin-list.md
+++ b/docs/superpowers/plans/2026-07-29-decker-tasks-pr-e-admin-list.md
@@ -1,0 +1,47 @@
+# Decker_Tasks PR E — Admin List & Chrome Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the task admin list table, its filters, and the edit-screen chrome (16 methods, 47 CC measured 2026-07-29) out of `Decker_Tasks` into two collaborators.
+
+**Architecture:** 47 summed CC is three points shy of the threshold — the same arithmetic that split PR C's cluster, so the same ruling applies rather than shipping a one-method-from-warning class. The seam is what the admin is looking at: `Decker_Task_Admin_List` owns the list table and its filters (`add_custom_columns` 1, `render_custom_columns` 2, `make_columns_sortable` 1, `custom_order_by_stack` 5, `filter_tasks_by_status` 5, `filter_tasks_by_taxonomies` 4, `map_taxonomy_filter_to_slug` 5 private, `add_taxonomy_filters` 2, `add_taxonomy_filter` 2 private, `remove_row_actions` 2 = 29); `Decker_Task_Admin_Chrome` owns the edit-screen and menu tweaks (`hide_visibility_options` 2, `disable_menu_order_field` 4, `hide_permalink_and_slug` 4, `change_publish_meta_box_title` 2, `disable_gutenberg` 2, `remove_add_new_link` 4 = 18). The only two internal dependencies both fall intra-group. Both classes are self-contained (no locks/today/order state): **zero permitted rewrites exist** — PR D's tripwire applies verbatim. Each class registers its own hooks (the 14 registrations split 8 list / 6 chrome, verified against `define_hooks` lines 111-132 at d609195).
+
+**Tech Stack:** PHP 7.4+/WordPress plugin, wp-env (PHPUnit 9.6), PHPMD 2.15, PHPCS.
+
+## Global Constraints
+
+- Bodies verbatim, visibilities unchanged, zero permitted rewrites (self-contained cluster) — any needed rewrite = BLOCKED naming it. Pre-extraction FULL caller sweep of all 16 names (file + repo, case-insensitive, callable-array form) — the PR C lesson.
+- Extraction script: the canonical PR C/D pattern with the campaign splice() (outward scan from the joint, collapse to exactly one blank line).
+- Hook fidelity: every registration moves with its exact priority/arg-count (`use_block_editor_for_post_type` at 10,2; `post_row_actions` at 10,2; `manage_decker_task_posts_custom_column` at 10,2; the rest default). Post-move `define_hooks` retains none of the 14.
+- Fresh-count the test retargets (expected file: `DeckerTasksAdminFiltersLockInTest`, but derive it). PHPUnit strictly serial; `rm -rf ~/.pdepend`; keyed diff zero-ADDED, every REMOVED justified (none expected — Decker_Tasks lands ≈156 CC / ≈35 methods / ≈18 public, still over the remaining thresholds). POT → "Refresh POT (entry reorder)". BLOCKED-ON-STEP. Branch `refactor/decker-tasks-admin-list`.
+
+---
+
+### Task 1: Baselines, sweep, extract both classes, retarget (one unit, one commit)
+
+**Files:**
+- Create: `includes/custom-post-types/class-decker-task-admin-list.php`, `includes/custom-post-types/class-decker-task-admin-chrome.php`
+- Modify: `includes/custom-post-types/class-decker-tasks.php`, `includes/class-decker.php`
+- Modify: the fresh-counted test file(s)
+
+**Interfaces:**
+- Produces: both classes with no-argument constructors registering their own hooks; the sixteen methods with today's exact signatures/visibilities.
+- Consumes: WordPress functions only.
+
+- [ ] **Step 1: Baselines (serial)** — `DeckerTasksAdminFiltersLockInTest` by path (fallback `--filter` with the real class name on the known quirk) and `DeckerTasksTest.php`; record OK lines. PHPMD snapshot → `/tmp/pr-e/phpmd-before.txt` (expect 7 lines).
+- [ ] **Step 2: Full caller sweep** of all 16 names. Expected callers: the 14 hook lines, the two intra-group pairs, the lock-in test's references. ANY other → BLOCKED.
+- [ ] **Step 3: Extraction** — two classes, established header style, hooks in constructors with fidelity per Global Constraints; remove the 16 methods + 14 hook lines from `Decker_Tasks`; wire `new Decker_Task_Admin_List();` and `new Decker_Task_Admin_Chrome();` beside the other collaborators; loader requires before `class-decker-tasks.php`.
+- [ ] **Step 4: Checks** — `php -l` ×4; hunk audit (headers in report; extracted regions + wiring only); stale sweep empty; fresh-cache phpmd: both new classes clean, `Decker_Tasks` alert kinds unchanged.
+- [ ] **Step 5: Retarget** the fresh-counted call sites to `( new Decker_Task_Admin_List() )->filter_tasks_by_taxonomies(...)` style (match the file's idiom; docblock owner references too); zero-stale; rerun both baseline suites (identical counts).
+- [ ] **Step 6: ONE commit** — "Move the task admin list and edit-screen chrome to their own classes", body noting the 47-CC arithmetic and the PR C precedent for the split.
+
+### Task 2: Verification and PR
+
+- [ ] **Step 1: keyed diff** vs `/tmp/pr-e/phpmd-before.txt` (zero ADDED; REMOVED justified or BLOCKED). **Step 2: PHPCS** (phpcbf mechanical only). **Step 3: translation gate** (POT → "Refresh POT (entry reorder)"). **Step 4: full suite serial once** (expect 903 green).
+- [ ] **Step 5: docs** — two rows in `docs/development.md`; spec Status → `PRs A (#296), B (#297), C (#298), D (#299) merged; PR E in review`. Commit.
+- [ ] **Step 6: /simplify** via Skill tool (skip loudly if unavailable) → IMMEDIATELY push → `gh pr create` (title `Decompose Decker_Tasks 5/7: admin list and chrome`; body: measured 47-CC split with PR C precedent, zero-rewrites tripwire silent, keyed-diff arithmetic, suite result, spec link) → CI + scan (expect 7) → report + contract. BLOCKED-ON-STEP, no silent idling.
+
+## Self-review notes
+
+- The split-at-47 ruling is stated with its precedent rather than left for a reviewer to question.
+- Hook fidelity (priorities/arg counts) is an explicit constraint because this cluster carries 14 registrations — the most hook surface of any PR in the sequence.

--- a/docs/superpowers/specs/2026-07-29-decker-tasks-decomposition-design.md
+++ b/docs/superpowers/specs/2026-07-29-decker-tasks-decomposition-design.md
@@ -1,7 +1,7 @@
 # Decker_Tasks and Task decomposition — design
 
 Date: 2026-07-29
-Status: approved design — PRs A (#296), B (#297), C (#298) merged; PR D in review
+Status: approved design — PRs A (#296), B (#297), C (#298), D (#299) merged; PR E in review
 Predecessors: PRs #290, #291, #292, #294, #295 (PHPMD codesize campaign, 39 → 8 open alerts)
 
 ## Goal

--- a/includes/class-decker.php
+++ b/includes/class-decker.php
@@ -154,6 +154,8 @@ class Decker {
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-task-order.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-task-order-hooks.php';
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-task-meta-boxes.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-task-admin-list.php';
+		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-task-admin-chrome.php';
 
 		require_once plugin_dir_path( __DIR__ ) . 'includes/custom-post-types/class-decker-tasks.php';
 

--- a/includes/custom-post-types/class-decker-task-admin-chrome.php
+++ b/includes/custom-post-types/class-decker-task-admin-chrome.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Edit-screen and menu chrome for tasks.
+ *
+ * The small admin-side tweaks around the decker_task edit screen and its
+ * menu entry: hiding the visibility and menu_order controls, hiding the
+ * permalink/slug box, relabeling the publish meta box, disabling
+ * Gutenberg, and removing the "Add New" submenu link. Presentation for
+ * administrators, kept apart from the post type registration and meta
+ * handling in Decker_Tasks.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Task_Admin_Chrome
+ */
+class Decker_Task_Admin_Chrome {
+
+	/**
+	 * Hook the edit-screen and menu tweaks.
+	 */
+	public function __construct() {
+		add_action( 'admin_head', array( $this, 'hide_visibility_options' ) );
+		add_action( 'admin_head', array( $this, 'disable_menu_order_field' ) );
+		add_action( 'admin_head', array( $this, 'hide_permalink_and_slug' ) );
+		add_action( 'admin_head', array( $this, 'change_publish_meta_box_title' ) );
+		add_action( 'use_block_editor_for_post_type', array( $this, 'disable_gutenberg' ), 10, 2 );
+		add_action( 'admin_menu', array( $this, 'remove_add_new_link' ) );
+	}
+
+	/**
+	 * Remove 'Add New' button for decker_task post type.
+	 */
+	public function remove_add_new_link() {
+		global $submenu;
+		// Remove the "Add New" submenu link.
+		if ( isset( $submenu['edit.php?post_type=decker_task'] ) ) {
+			foreach ( $submenu['edit.php?post_type=decker_task'] as $key => $item ) {
+				// Searches for the "Add New Entry" item.
+				if ( 'post-new.php?post_type=decker_task' === $item[2] ) {
+					unset( $submenu['edit.php?post_type=decker_task'][ $key ] );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Hide the permalink and slug for decker_task.
+	 */
+	public function hide_permalink_and_slug() {
+		$screen = get_current_screen();
+		if ( $screen && 'decker_task' == $screen->post_type && 'post' == $screen->base ) {
+			echo '<style type="text/css">
+				#edit-slug-box, #post-name { display: none; }
+			</style>';
+		}
+	}
+
+	/**
+	 * Disables the menu_order field in the admin interface for decker_task.
+	 */
+	public function disable_menu_order_field() {
+		$screen = get_current_screen();
+		if ( $screen && 'decker_task' === $screen->post_type && 'post' === $screen->base ) {
+			?>
+			<script type="text/javascript">
+				document.addEventListener('DOMContentLoaded', function() {
+					// Disable the menu_order field.
+					var menuOrderField = document.getElementById('menu_order');
+					if (menuOrderField) {
+						menuOrderField.disabled = true;
+					}
+				});
+			</script>
+			<?php
+		}
+	}
+
+	/**
+	 * Disable Gutenberg editor for decker_task.
+	 *
+	 * @param bool   $current_status The current status.
+	 * @param string $post_type      The post type.
+	 * @return bool The modified status.
+	 */
+	public function disable_gutenberg( $current_status, $post_type ) {
+		if ( 'decker_task' === $post_type ) {
+			return false;
+		}
+		return $current_status;
+	}
+
+	/**
+	 * Changes the title of the publish meta box for the 'decker_task' post type.
+	 *
+	 * Updates the title of the publish meta box to "Status" using JavaScript
+	 * when editing or creating a task of the 'decker_task' post type.
+	 *
+	 * @return void Outputs a script to modify the meta box title dynamically.
+	 */
+	public function change_publish_meta_box_title() {
+		global $post_type;
+		if ( 'decker_task' === $post_type ) {
+			echo '<script>
+	            jQuery(document).ready(function($) {
+	                jQuery("#submitdiv .hndle").text("' . esc_html__( 'Status', 'decker' ) . '");
+	            });
+	        </script>';
+		}
+	}
+
+	/**
+	 * Hide visibility options for decker_task post type.
+	 */
+	public function hide_visibility_options() {
+		global $post_type;
+		if ( 'decker_task' == $post_type ) {
+
+			echo '<style type="text/css">
+	            .misc-pub-section.misc-pub-visibility {
+	                display: none;
+	            }
+		        /* hide the parent of the group of password and private */
+		        .inline-edit-group.wp-clearfix .inline-edit-password-input,
+		        .inline-edit-group.wp-clearfix .inline-edit-private,
+		        .inline-edit-group.wp-clearfix .inline-edit-or,
+		        .inline-edit-group.wp-clearfix {
+		            display: none;
+		        }
+		        .page-title-action {
+	               	display: none !important;
+	            }
+			</style>';
+		}
+	}
+}

--- a/includes/custom-post-types/class-decker-task-admin-list.php
+++ b/includes/custom-post-types/class-decker-task-admin-list.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Admin list-table presentation and filters for tasks.
+ *
+ * Owns the decker_task list table: its custom columns, the "order by
+ * stack" tweak, hiding the default row actions, and the admin-side
+ * status/taxonomy filters (including the numeric-id-to-slug mapping the
+ * taxonomy dropdowns need). Presentation and filtering for administrators,
+ * kept apart from the post type registration and meta handling in
+ * Decker_Tasks.
+ *
+ * @package    Decker
+ * @subpackage Decker/includes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Decker_Task_Admin_List
+ */
+class Decker_Task_Admin_List {
+
+	/**
+	 * Hook the list-table columns and the admin-side filters.
+	 */
+	public function __construct() {
+		add_filter( 'parse_query', array( $this, 'filter_tasks_by_status' ) );
+		add_filter( 'parse_query', array( $this, 'filter_tasks_by_taxonomies' ) );
+		add_action( 'restrict_manage_posts', array( $this, 'add_taxonomy_filters' ) );
+		add_filter( 'manage_decker_task_posts_columns', array( $this, 'add_custom_columns' ) );
+		add_action( 'manage_decker_task_posts_custom_column', array( $this, 'render_custom_columns' ), 10, 2 );
+		add_filter( 'manage_edit-decker_task_sortable_columns', array( $this, 'make_columns_sortable' ) );
+		add_filter( 'post_row_actions', array( $this, 'remove_row_actions' ), 10, 2 );
+		add_action( 'pre_get_posts', array( $this, 'custom_order_by_stack' ) );
+	}
+
+	/**
+	 * Make custom columns sortable.
+	 *
+	 * @param array $columns Existing sortable columns.
+	 * @return array Modified sortable columns.
+	 */
+	public function make_columns_sortable( $columns ) {
+		$columns['stack'] = 'stack';
+		return $columns;
+	}
+
+	/**
+	 * Modify the order of the 'decker_task' post type in the admin when sorting by 'stack'.
+	 *
+	 * @param WP_Query $query The current query object.
+	 */
+	public function custom_order_by_stack( $query ) {
+		if ( ! is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+
+		if ( 'decker_task' === $query->get( 'post_type' ) && 'stack' === $query->get( 'orderby' ) ) {
+			$query->set( 'meta_key', 'stack' );
+			$query->set( 'orderby', 'meta_value' );
+		}
+	}
+
+	/**
+	 * Add custom columns to the task list table.
+	 *
+	 * @param array $columns Existing columns.
+	 * @return array Modified columns.
+	 */
+	public function add_custom_columns( $columns ) {
+		unset( $columns['date'] ); // Remove the date column if needed.
+		$columns['stack'] = __( 'Stack', 'decker' );
+		return $columns;
+	}
+
+	/**
+	 * Render custom columns in the task list table.
+	 *
+	 * @param string $column  The name of the column.
+	 * @param int    $post_id The ID of the post.
+	 */
+	public function render_custom_columns( $column, $post_id ) {
+		switch ( $column ) {
+			case 'stack':
+				echo esc_html( get_post_meta( $post_id, 'stack', true ) );
+				break;
+		}
+	}
+
+	/**
+	 * Remove row actions from the task list table.
+	 *
+	 * @param array  $actions Existing actions.
+	 * @param object $post    The current post object.
+	 * @return array Modified actions.
+	 */
+	public function remove_row_actions( $actions, $post ) {
+		if ( 'decker_task' === $post->post_type ) {
+			return array(); // Remove all actions.
+		}
+		return $actions;
+	}
+
+	/**
+	 * Filter tasks to show only published by default in the admin list.
+	 *
+	 * @param WP_Query $query The current query object.
+	 */
+	public function filter_tasks_by_status( $query ) {
+		global $pagenow;
+		$post_type = isset( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : '';
+
+		if ( 'edit.php' === $pagenow && 'decker_task' === $post_type && ! isset( $_GET['post_status'] ) ) {
+			$query->set( 'post_status', 'publish' );
+		}
+	}
+
+	/**
+	 * Filter tasks by taxonomies.
+	 *
+	 * @param WP_Query $query The current query object.
+	 */
+	public function filter_tasks_by_taxonomies( $query ) {
+		global $pagenow;
+		$qv = &$query->query_vars;
+		if ( 'edit.php' == $pagenow && isset( $qv['post_type'] ) && 'decker_task' == $qv['post_type'] ) {
+			$this->map_taxonomy_filter_to_slug( $qv, 'decker_board' );
+			$this->map_taxonomy_filter_to_slug( $qv, 'decker_label' );
+		}
+	}
+
+	/**
+	 * Replace a numeric taxonomy query var with the matching term slug in place.
+	 *
+	 * @param array  $qv       The query vars array, passed by reference for in-place mutation.
+	 * @param string $taxonomy The taxonomy name.
+	 */
+	private function map_taxonomy_filter_to_slug( array &$qv, string $taxonomy ) {
+		if ( isset( $qv[ $taxonomy ] ) && is_numeric( $qv[ $taxonomy ] ) && 0 != $qv[ $taxonomy ] ) {
+			$term = get_term_by( 'id', $qv[ $taxonomy ], $taxonomy );
+			if ( $term ) {
+				$qv[ $taxonomy ] = $term->slug;
+			}
+		}
+	}
+
+	/**
+	 * Add taxonomy filters to the admin posts list.
+	 */
+	public function add_taxonomy_filters() {
+		global $typenow;
+		if ( 'decker_task' == $typenow ) {
+			$this->add_taxonomy_filter( 'decker_board', __( 'Show All Boards', 'decker' ) );
+			$this->add_taxonomy_filter( 'decker_label', __( 'Show All Labels', 'decker' ) );
+		}
+	}
+
+	/**
+	 * Add a taxonomy filter to the admin posts list.
+	 *
+	 * @param string $taxonomy The taxonomy name.
+	 * @param string $label    The label for the dropdown.
+	 */
+	private function add_taxonomy_filter( $taxonomy, $label ) {
+		$selected      = isset( $_GET[ $taxonomy ] ) ? sanitize_text_field( wp_unslash( $_GET[ $taxonomy ] ) ) : '';
+		$info_taxonomy = get_taxonomy( $taxonomy );
+		wp_dropdown_categories(
+			array(
+				'show_option_all' => $label . $info_taxonomy->label,
+				'taxonomy'        => $taxonomy,
+				'name'            => $taxonomy,
+				'orderby'         => 'name',
+				'selected'        => $selected,
+				'show_count'      => true,
+				'hide_empty'      => true,
+			)
+		);
+	}
+}

--- a/includes/custom-post-types/class-decker-tasks.php
+++ b/includes/custom-post-types/class-decker-tasks.php
@@ -43,6 +43,10 @@ class Decker_Tasks {
 
 		// The edit-screen meta boxes own their own hook.
 		new Decker_Task_Meta_Boxes();
+
+		// The admin list table and the edit-screen chrome own their own hooks.
+		new Decker_Task_Admin_List();
+		new Decker_Task_Admin_Chrome();
 	}
 
 	/**
@@ -108,28 +112,10 @@ class Decker_Tasks {
 		add_action( 'before_delete_post', array( $this, 'handle_task_deletion' ) );
 		add_action( 'transition_post_status', array( $this, 'handle_task_status_change' ), 10, 3 );
 
-		add_action( 'admin_head', array( $this, 'hide_visibility_options' ) );
-		add_action( 'admin_head', array( $this, 'disable_menu_order_field' ) );
-
 		add_action( 'save_post', array( $this, 'save_meta' ), 10, 3 );
-		add_action( 'admin_head', array( $this, 'hide_permalink_and_slug' ) );
-		add_action( 'admin_head', array( $this, 'change_publish_meta_box_title' ) );
-		add_filter( 'parse_query', array( $this, 'filter_tasks_by_status' ) );
-		add_filter( 'parse_query', array( $this, 'filter_tasks_by_taxonomies' ) );
-		add_action( 'restrict_manage_posts', array( $this, 'add_taxonomy_filters' ) );
-		add_action( 'use_block_editor_for_post_type', array( $this, 'disable_gutenberg' ), 10, 2 );
-
-		add_filter( 'manage_decker_task_posts_columns', array( $this, 'add_custom_columns' ) );
-		add_action( 'manage_decker_task_posts_custom_column', array( $this, 'render_custom_columns' ), 10, 2 );
-		add_filter( 'manage_edit-decker_task_sortable_columns', array( $this, 'make_columns_sortable' ) );
-		add_filter( 'post_row_actions', array( $this, 'remove_row_actions' ), 10, 2 );
-
-		add_action( 'pre_get_posts', array( $this, 'custom_order_by_stack' ) );
 
 		add_action( 'wp_ajax_save_decker_task', array( $this, 'handle_save_decker_task' ) );
 		add_action( 'wp_ajax_nopriv_save_decker_task', array( $this, 'handle_save_decker_task' ) );
-
-		add_action( 'admin_menu', array( $this, 'remove_add_new_link' ) );
 
 		add_filter( 'wp_unique_filename', array( $this, 'custom_unique_filename' ), 10, 4 );
 
@@ -166,90 +152,6 @@ class Decker_Tasks {
 			}
 		}
 		return $filename;
-	}
-
-
-	/**
-	 * Make custom columns sortable.
-	 *
-	 * @param array $columns Existing sortable columns.
-	 * @return array Modified sortable columns.
-	 */
-	public function make_columns_sortable( $columns ) {
-		$columns['stack'] = 'stack';
-		return $columns;
-	}
-
-	/**
-	 * Modify the order of the 'decker_task' post type in the admin when sorting by 'stack'.
-	 *
-	 * @param WP_Query $query The current query object.
-	 */
-	public function custom_order_by_stack( $query ) {
-		if ( ! is_admin() || ! $query->is_main_query() ) {
-			return;
-		}
-
-		if ( 'decker_task' === $query->get( 'post_type' ) && 'stack' === $query->get( 'orderby' ) ) {
-			$query->set( 'meta_key', 'stack' );
-			$query->set( 'orderby', 'meta_value' );
-		}
-	}
-
-	/**
-	 * Add custom columns to the task list table.
-	 *
-	 * @param array $columns Existing columns.
-	 * @return array Modified columns.
-	 */
-	public function add_custom_columns( $columns ) {
-		unset( $columns['date'] ); // Remove the date column if needed.
-		$columns['stack'] = __( 'Stack', 'decker' );
-		return $columns;
-	}
-
-	/**
-	 * Render custom columns in the task list table.
-	 *
-	 * @param string $column  The name of the column.
-	 * @param int    $post_id The ID of the post.
-	 */
-	public function render_custom_columns( $column, $post_id ) {
-		switch ( $column ) {
-			case 'stack':
-				echo esc_html( get_post_meta( $post_id, 'stack', true ) );
-				break;
-		}
-	}
-
-	/**
-	 * Remove row actions from the task list table.
-	 *
-	 * @param array  $actions Existing actions.
-	 * @param object $post    The current post object.
-	 * @return array Modified actions.
-	 */
-	public function remove_row_actions( $actions, $post ) {
-		if ( 'decker_task' === $post->post_type ) {
-			return array(); // Remove all actions.
-		}
-		return $actions;
-	}
-
-	/**
-	 * Remove 'Add New' button for decker_task post type.
-	 */
-	public function remove_add_new_link() {
-		global $submenu;
-		// Remove the "Add New" submenu link.
-		if ( isset( $submenu['edit.php?post_type=decker_task'] ) ) {
-			foreach ( $submenu['edit.php?post_type=decker_task'] as $key => $item ) {
-				// Searches for the "Add New Entry" item.
-				if ( 'post-new.php?post_type=decker_task' === $item[2] ) {
-					unset( $submenu['edit.php?post_type=decker_task'][ $key ] );
-				}
-			}
-		}
 	}
 
 	/**
@@ -498,20 +400,6 @@ class Decker_Tasks {
 	}
 
 	/**
-	 * Filter tasks to show only published by default in the admin list.
-	 *
-	 * @param WP_Query $query The current query object.
-	 */
-	public function filter_tasks_by_status( $query ) {
-		global $pagenow;
-		$post_type = isset( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : '';
-
-		if ( 'edit.php' === $pagenow && 'decker_task' === $post_type && ! isset( $_GET['post_status'] ) ) {
-			$query->set( 'post_status', 'publish' );
-		}
-	}
-
-	/**
 	 * Save the custom meta fields.
 	 *
 	 * @param int     $post_id The current post ID.
@@ -682,158 +570,6 @@ class Decker_Tasks {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		update_post_meta( $post_id, '_user_date_relations', $relations );
-	}
-
-	/**
-	 * Hide the permalink and slug for decker_task.
-	 */
-	public function hide_permalink_and_slug() {
-		$screen = get_current_screen();
-		if ( $screen && 'decker_task' == $screen->post_type && 'post' == $screen->base ) {
-			echo '<style type="text/css">
-				#edit-slug-box, #post-name { display: none; }
-			</style>';
-		}
-	}
-
-	/**
-	 * Disables the menu_order field in the admin interface for decker_task.
-	 */
-	public function disable_menu_order_field() {
-		$screen = get_current_screen();
-		if ( $screen && 'decker_task' === $screen->post_type && 'post' === $screen->base ) {
-			?>
-			<script type="text/javascript">
-				document.addEventListener('DOMContentLoaded', function() {
-					// Disable the menu_order field.
-					var menuOrderField = document.getElementById('menu_order');
-					if (menuOrderField) {
-						menuOrderField.disabled = true;
-					}
-				});
-			</script>
-			<?php
-		}
-	}
-
-	/**
-	 * Filter tasks by taxonomies.
-	 *
-	 * @param WP_Query $query The current query object.
-	 */
-	public function filter_tasks_by_taxonomies( $query ) {
-		global $pagenow;
-		$qv = &$query->query_vars;
-		if ( 'edit.php' == $pagenow && isset( $qv['post_type'] ) && 'decker_task' == $qv['post_type'] ) {
-			$this->map_taxonomy_filter_to_slug( $qv, 'decker_board' );
-			$this->map_taxonomy_filter_to_slug( $qv, 'decker_label' );
-		}
-	}
-
-	/**
-	 * Replace a numeric taxonomy query var with the matching term slug in place.
-	 *
-	 * @param array  $qv       The query vars array, passed by reference for in-place mutation.
-	 * @param string $taxonomy The taxonomy name.
-	 */
-	private function map_taxonomy_filter_to_slug( array &$qv, string $taxonomy ) {
-		if ( isset( $qv[ $taxonomy ] ) && is_numeric( $qv[ $taxonomy ] ) && 0 != $qv[ $taxonomy ] ) {
-			$term = get_term_by( 'id', $qv[ $taxonomy ], $taxonomy );
-			if ( $term ) {
-				$qv[ $taxonomy ] = $term->slug;
-			}
-		}
-	}
-
-	/**
-	 * Add taxonomy filters to the admin posts list.
-	 */
-	public function add_taxonomy_filters() {
-		global $typenow;
-		if ( 'decker_task' == $typenow ) {
-			$this->add_taxonomy_filter( 'decker_board', __( 'Show All Boards', 'decker' ) );
-			$this->add_taxonomy_filter( 'decker_label', __( 'Show All Labels', 'decker' ) );
-		}
-	}
-
-	/**
-	 * Add a taxonomy filter to the admin posts list.
-	 *
-	 * @param string $taxonomy The taxonomy name.
-	 * @param string $label    The label for the dropdown.
-	 */
-	private function add_taxonomy_filter( $taxonomy, $label ) {
-		$selected      = isset( $_GET[ $taxonomy ] ) ? sanitize_text_field( wp_unslash( $_GET[ $taxonomy ] ) ) : '';
-		$info_taxonomy = get_taxonomy( $taxonomy );
-		wp_dropdown_categories(
-			array(
-				'show_option_all' => $label . $info_taxonomy->label,
-				'taxonomy'        => $taxonomy,
-				'name'            => $taxonomy,
-				'orderby'         => 'name',
-				'selected'        => $selected,
-				'show_count'      => true,
-				'hide_empty'      => true,
-			)
-		);
-	}
-
-	/**
-	 * Disable Gutenberg editor for decker_task.
-	 *
-	 * @param bool   $current_status The current status.
-	 * @param string $post_type      The post type.
-	 * @return bool The modified status.
-	 */
-	public function disable_gutenberg( $current_status, $post_type ) {
-		if ( 'decker_task' === $post_type ) {
-			return false;
-		}
-		return $current_status;
-	}
-
-	/**
-	 * Changes the title of the publish meta box for the 'decker_task' post type.
-	 *
-	 * Updates the title of the publish meta box to "Status" using JavaScript
-	 * when editing or creating a task of the 'decker_task' post type.
-	 *
-	 * @return void Outputs a script to modify the meta box title dynamically.
-	 */
-	public function change_publish_meta_box_title() {
-		global $post_type;
-		if ( 'decker_task' === $post_type ) {
-			echo '<script>
-	            jQuery(document).ready(function($) {
-	                jQuery("#submitdiv .hndle").text("' . esc_html__( 'Status', 'decker' ) . '");
-	            });
-	        </script>';
-		}
-	}
-
-	/**
-	 * Hide visibility options for decker_task post type.
-	 */
-	public function hide_visibility_options() {
-		global $post_type;
-		if ( 'decker_task' == $post_type ) {
-
-			echo '<style type="text/css">
-	            .misc-pub-section.misc-pub-visibility {
-	                display: none;
-	            }
-		        /* hide the parent of the group of password and private */
-		        .inline-edit-group.wp-clearfix .inline-edit-password-input,
-		        .inline-edit-group.wp-clearfix .inline-edit-private,
-		        .inline-edit-group.wp-clearfix .inline-edit-or,
-		        .inline-edit-group.wp-clearfix {
-		            display: none;
-		        }
-		        .page-title-action {
-	               	display: none !important;
-	            }
-			</style>';
-		}
 	}
 
 	/**

--- a/languages/decker.pot
+++ b/languages/decker.pot
@@ -849,6 +849,15 @@ msgstr ""
 msgid "New Label Name"
 msgstr ""
 
+msgid "Status"
+msgstr ""
+
+msgid "Show All Boards"
+msgstr ""
+
+msgid "Show All Labels"
+msgstr ""
+
 msgid "Invalid task ID."
 msgstr ""
 
@@ -1030,15 +1039,6 @@ msgid "Archived"
 msgstr ""
 
 msgid "Archivado"
-msgstr ""
-
-msgid "Show All Boards"
-msgstr ""
-
-msgid "Show All Labels"
-msgstr ""
-
-msgid "Status"
 msgstr ""
 
 msgid "Task saved successfully."

--- a/tests/unit/includes/custom-post-types/DeckerTasksAdminFiltersLockInTest.php
+++ b/tests/unit/includes/custom-post-types/DeckerTasksAdminFiltersLockInTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Characterization test for Decker_Tasks::filter_tasks_by_taxonomies().
+ * Characterization test for Decker_Task_Admin_List::filter_tasks_by_taxonomies().
  *
  * Pins the by-reference in-place mutation of $query->query_vars before the
  * method is refactored to share a helper.
@@ -46,7 +46,7 @@ class DeckerTasksAdminFiltersLockInTest extends Decker_Test_Base {
 			'decker_label' => (string) $this->label_id,
 		);
 
-		( new Decker_Tasks() )->filter_tasks_by_taxonomies( $query );
+		( new Decker_Task_Admin_List() )->filter_tasks_by_taxonomies( $query );
 
 		$this->assertEquals(
 			get_term( $this->board_id )->slug,
@@ -66,7 +66,7 @@ class DeckerTasksAdminFiltersLockInTest extends Decker_Test_Base {
 			'decker_board' => '0',
 			'decker_label' => 'already-a-slug',
 		);
-		( new Decker_Tasks() )->filter_tasks_by_taxonomies( $query2 );
+		( new Decker_Task_Admin_List() )->filter_tasks_by_taxonomies( $query2 );
 		$this->assertEquals( '0', $query2->query_vars['decker_board'] );
 		$this->assertEquals( 'already-a-slug', $query2->query_vars['decker_label'] );
 


### PR DESCRIPTION
Fifth PR of the sequence in docs/superpowers/specs/2026-07-29-decker-tasks-decomposition-design.md (merged: #296, #297, #298, #299).

Moves the task admin list table, its filters, and the edit-screen chrome (16 methods, 47 measured complexity) into `Decker_Task_Admin_List` and `Decker_Task_Admin_Chrome`. Two classes rather than the spec's one: 47 summed complexity is three points shy of the 50 threshold — the same arithmetic that split PR C's cluster, applied by precedent rather than shipping a one-method-from-warning class.

This is the largest hook surface of the sequence — 14 registrations — so **hook fidelity was the review's sharpest lens**: the reviewer rebuilt the hook table independently from the base commit and matched all 14 registrations character-by-character, explicit arg-counts and implicit defaults alike. The cluster is self-contained, and the zero-permitted-rewrites tripwire stayed silent: all 16 bodies byte-identical.

**This PR clears no alert**: keyed PHPMD diff is the identical 7-entry list, zero added, zero removed; both new classes clean. `Decker_Tasks` lands at 156 complexity, 35 methods, 14 public. The public count only drops to 13 across PRs F and G under the delegator policy (`handle_save_decker_task` and `create_or_update_task` keep public delegators), so `TooManyPublicMethods` needs its own resolution in the PR F/G plans. Full suite green.
