### PR TITLE
Fix notification panel to keep and display the newest entries

### DIFF
--- a/includes/class-decker-notification-ajax.php
+++ b/includes/class-decker-notification-ajax.php
@@ -102,14 +102,14 @@ class Decker_Notification_Ajax {
 
 		$all_notifications = $this->store->get_notifications_meta( $user_id, 'decker_all_notifications' );
 
-		// Reverse so newest is at the front.
+		// Sort by time so the newest is at the front.
 		usort(
 			$all_notifications,
 			function ( $a, $b ) {
-				return strtotime( $a['time'] ) - strtotime( $b['time'] );
+				return strtotime( $b['time'] ) - strtotime( $a['time'] );
 			}
 		);
-		// Return only the last 15 (most recent first).
+		// Return only the newest 15 (most recent first).
 		$last_notifications = array_slice( $all_notifications, 0, Decker_Notification_Store::MAX_NOTIFICATIONS );
 
 		// Map them to the same structure used in JS.

--- a/public/assets/js/decker-heartbeat.js
+++ b/public/assets/js/decker-heartbeat.js
@@ -358,7 +358,10 @@ console.log('loading decker-heartbeat.js');
         })
             .done(function(response) {
                 if (response.success && Array.isArray(response.data)) {
-                    response.data.forEach(function(notification) {
+                    // The response is ordered newest first and addNotification()
+                    // prepends, so iterate a reversed copy to keep the newest
+                    // notification at the top of the panel.
+                    response.data.slice().reverse().forEach(function(notification) {
                         addNotification(notification, false);
                     });
                 }

--- a/tests/unit/includes/NotificationHandlerTest.php
+++ b/tests/unit/includes/NotificationHandlerTest.php
@@ -566,14 +566,13 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 	}
 
 	/**
-	 * Locks the CURRENT ascending sort + front slice for the AJAX endpoint.
+	 * The AJAX endpoint must return the newest notifications, newest first.
 	 *
-	 * This documents a bug rather than endorsing it: the endpoint's comments
-	 * promise newest-first but the code returns oldest-first and drops the
-	 * newest entries once over the cap. Tracked in issue #293 — when that is
-	 * fixed, this test must flip with it.
+	 * Regression test for issue #293: the endpoint used to sort ascending and
+	 * slice from the front, which kept the oldest entries and dropped the
+	 * newest ones once over the cap.
 	 */
-	public function test_ajax_get_notifications_returns_oldest_first_and_caps_at_15() {
+	public function test_ajax_get_notifications_returns_newest_first_and_caps_at_15() {
 		$notifications = array();
 		for ( $i = 1; $i <= 20; $i++ ) {
 			$notifications[] = array(
@@ -596,8 +595,13 @@ class DeckerNotificationHandlerTest extends Decker_Test_Base {
 
 		$this->assertTrue( $json['success'], 'Response should be successful.' );
 		$this->assertCount( 15, $json['data'], 'Should cap at MAX_NOTIFICATIONS.' );
-		$this->assertSame( 'n1', $json['data'][0]['title'], 'Oldest notification should be first.' );
-		$this->assertSame( 'n15', $json['data'][14]['title'], 'Newest five should be dropped from the front slice.' );
+		$this->assertSame( 'n20', $json['data'][0]['title'], 'Newest notification should be first.' );
+		$this->assertSame( 'n6', $json['data'][14]['title'], 'Oldest kept notification should be last.' );
+
+		$returned_titles = wp_list_pluck( $json['data'], 'title' );
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$this->assertNotContains( 'n' . $i, $returned_titles, 'Notifications beyond the cap must be excluded.' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- return the newest stored notifications before applying the response cap
- keep the AJAX response ordered newest first
- preserve newest-first visual ordering during the initial panel render

## TDD

- updated the regression test first to require the newest 15 notifications
- confirmed the test failed with the previous ascending sort (expected `n20`, got `n1`)
- implemented the backend and frontend ordering fixes

## Testing

- `npx wp-env run tests-cli --env-cwd=wp-content/plugins/decker ./vendor/bin/phpunit -- --filter "DeckerNotificationHandlerTest::test_ajax_get_notifications_returns_newest_first_and_caps_at_15"` — failed before the fix (`n1` first), passes after
- `npx wp-env run tests-cli --env-cwd=wp-content/plugins/decker ./vendor/bin/phpunit -- --filter "DeckerNotificationHandlerTest"` — OK (24 tests, 92 assertions)
- `npx wp-env run tests-cli --env-cwd=wp-content/plugins/decker ./vendor/bin/phpunit -- --filter "NotificationHandlerEdgeCasesTest"` — OK (9 tests, 9 assertions)
- `make lint` — clean (phpcs, zero violations)
- `make test` — OK (903 tests, 9768 assertions)
- `make check-untranslated` — exit 0 (no string changes, no catalogue churn)
- `npm run test:js` — 93/93 passing (none cover this file; see below)

## Frontend ordering verification

`decker-heartbeat.js` is a jQuery IIFE with no module exports, and jQuery is not part of the Jest setup, so adding a JS regression test would mean introducing new test scaffolding solely for this fix — avoided per the issue guidance. Verified by inspection instead: the AJAX response is now newest-first, `addNotification()` prepends each item, and `loadInitialNotifications()` iterates a reversed copy (`response.data.slice().reverse()`), so the last prepended item is the newest and lands at the top of the panel. `response.data` itself is not mutated. Heartbeat-tick handling (new incoming notifications, `showAlert = true`) is untouched.

Fixes #293
