### PR TITLE
Report PHP and JavaScript coverage to Codecov

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,7 @@
 .github
 .idea
 .wordpress-org
+artifacts
 bin
 build
 build-cs

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,12 @@ languages/*.pot            export-ignore
 # Exclude development files
 *.css.map 				   export-ignore
 /vendor/                   export-ignore
+# Test and coverage output. `composer archive` does not read .gitignore, so
+# without this the reports written by `make test-coverage` and the Playwright
+# runs would travel inside the release ZIP.
+artifacts/                 export-ignore
 blueprint.json             export-ignore
+codecov.yml                export-ignore
 CHANGELOG.md               export-ignore
 CODE_OF_CONDUCT.md         export-ignore
 composer.json              export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 
 permissions:
   contents: read
+  # Codecov authenticates with OIDC instead of a token kept as a secret.
+  # Without this permission no identity token can be issued.
+  id-token: write
 
 jobs:
   lint_and_test:
@@ -41,9 +44,10 @@ jobs:
       - name: Setup wp-env
         run: npm -g --no-fund i @wordpress/env
 
-      # Start wp-env environment
+      # Start wp-env environment. Xdebug is asked for at start-up: the
+      # containers do not enable it, and PHPUnit needs it to measure coverage.
       - name: Start wp-env
-        run: make up
+        run: make up WP_ENV_FLAGS=--xdebug=coverage
 
       - name: Run code linting
         run: make lint
@@ -51,12 +55,33 @@ jobs:
       - name: Run plugin check
         run: make check-plugin
 
-      - name: Run unit tests
-        run: make test
+      - name: Run unit tests with coverage
+        run: make test-coverage
+
+      - name: Upload PHP coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: artifacts/coverage/clover.xml
+          flags: php
+          # The uploader otherwise also picks up artifacts/coverage/coverage.txt,
+          # a human-readable summary it cannot parse as a coverage report.
+          disable_search: true
 
       # E2E Tests with Playwright
       - name: Install npm dependencies and Playwright
         run: npm install && npx playwright install --with-deps chromium
+
+      - name: Run JavaScript unit tests with coverage
+        run: make test-js
+
+      - name: Upload JavaScript coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: artifacts/coverage-js/lcov.info
+          flags: javascript
+          disable_search: true
 
       - name: Run E2E tests
         run: make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,13 @@ start-if-not-running: check-docker
 
 # Bring up the environment. Always calls `wp-env start` (idempotent), so it
 # (re)syncs the containers instead of skipping when something only appears up.
+# WP_ENV_FLAGS passes options through to `wp-env start`; CI uses it to bring
+# the environment up with Xdebug in coverage mode:
+#   make up WP_ENV_FLAGS=--xdebug=coverage
+WP_ENV_FLAGS ?=
 up: check-docker
 	$(call free_ports,8888 8889)
-	npx wp-env start
+	npx wp-env start $(WP_ENV_FLAGS)
 	-npx wp-env run cli wp plugin activate decker
 	@echo "Visit http://localhost:8888/wp-admin/ to access the Decker dashboard."
 
@@ -112,6 +116,23 @@ test: start-if-not-running
 	if [ -n "$(FILE)" ]; then CMD="$$CMD $(FILE)"; fi; \
 	if [ -n "$(FILTER)" ]; then CMD="$$CMD --filter $(FILTER)"; fi; \
 	npx wp-env run tests-cli --env-cwd=wp-content/plugins/decker $$CMD --testdox --colors=always
+
+# Run the PHPUnit suite with coverage, writing the reports CI uploads to
+# Codecov (clover.xml) plus a text summary and a browsable HTML report.
+# IMPORTANT: the containers need Xdebug in coverage mode, which is not the
+# default. If the report comes out at 0%, restart the environment with:
+#   npx wp-env start --xdebug=coverage
+test-coverage: start-if-not-running
+	@mkdir -p artifacts/coverage
+	@CMD="env XDEBUG_MODE=coverage ./vendor/bin/phpunit --testdox --colors=always --coverage-text=artifacts/coverage/coverage.txt --coverage-html artifacts/coverage/html --coverage-clover artifacts/coverage/clover.xml"; \
+	if [ -n "$(FILE)" ]; then CMD="$$CMD $(FILE)"; fi; \
+	if [ -n "$(FILTER)" ]; then CMD="$$CMD --filter $(FILTER)"; fi; \
+	npx wp-env run tests-cli --env-cwd=wp-content/plugins/decker $$CMD; \
+	EXIT_CODE=$$?; \
+	echo ""; \
+	grep -E "^\s*(Classes|Methods|Lines):" artifacts/coverage/coverage.txt 2>/dev/null || echo "Coverage data not available"; \
+	echo "Full report: artifacts/coverage/html/index.html"; \
+	exit $$EXIT_CODE
 
 # Run unit tests in verbose mode. Honor TEST filter if provided.
 test-verbose: start-if-not-running
@@ -323,6 +344,8 @@ help:
 	@echo "                         make test FILE=tests/MyTest.php"
 	@echo "                         make test FILE=tests/MyTest.php FILTER=test_my_feature"
 	@echo ""
+	@echo "  test-coverage      - Run PHPUnit with coverage into artifacts/coverage/"
+	@echo "                       (needs: npx wp-env start --xdebug=coverage)"
 	@echo "  test-js            - Run JavaScript unit tests with Jest"
 	@echo "  test-e2e           - Run E2E tests (non-interactive)"
 	@echo "  test-e2e-visual    - Run E2E tests with visual test UI"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Decker
 
+![CI](https://img.shields.io/github/actions/workflow/status/ateeducacion/wp-decker/ci.yml?label=CI)
+[![codecov](https://codecov.io/gh/ateeducacion/wp-decker/graph/badge.svg)](https://codecov.io/gh/ateeducacion/wp-decker)
 ![WordPress Version](https://img.shields.io/badge/WordPress-6.1-blue)
 ![Language](https://img.shields.io/badge/Language-PHP-orange)
 ![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+# Codecov configuration.
+#
+# Statuses are informational: Codecov comments the coverage of every pull
+# request but never marks it as failed. A large part of this plugin can only be
+# exercised with a full WordPress environment loaded, so a blocking threshold
+# would measure what is testable rather than what is well done.
+#
+# To make these blocking, set `informational: false`.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+# PHPUnit runs inside the wp-env container, where the plugin lives under
+# /var/www/html/wp-content/plugins/decker, and Clover records those absolute
+# paths. Stripping the prefix maps every entry back onto the repository;
+# without it Codecov cannot match a single file. The Jest LCOV report already
+# uses repository-relative paths and needs no fix.
+fixes:
+  - "/var/www/html/wp-content/plugins/decker/::"
+
+# Coverage arrives from two suites, each uploaded under its own flag (`php` and
+# `javascript`, set in the workflow). No `paths` are declared for them on
+# purpose: a path list also filters the report, and it would quietly drop the
+# root-level decker.php and uninstall.php from the PHP numbers.
+comment:
+  layout: "condensed_header, diff, flags, files"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,12 @@
 module.exports = {
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/tests/js/**/*.test.js' ],
+	coverageDirectory: 'artifacts/coverage-js',
+	coverageReporters: [ 'text', 'lcov' ],
+	// `collectCoverageFrom` is deliberately left unset. Most suites here read a
+	// source file with fs.readFileSync and evaluate it by hand, which Jest
+	// cannot instrument, so listing public/assets/js/** would report those files
+	// as 0% covered while their tests pass. Only the files loaded through
+	// `require()` are measured; converting the readFileSync suites is what
+	// widens this number, not a wider glob.
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "composer:tests-cli": "wp-env run tests-cli --env-cwd=wp-content/plugins/decker composer",
     "test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.js",
     "test:unit": "wp-env run tests-cli --env-cwd=wp-content/plugins/decker ./vendor/bin/phpunit",
-    "test:js": "jest --config jest.config.js"
+    "test:js": "jest --config jest.config.js --coverage"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,19 @@
   backupGlobals="false"
   colors="true"
   xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">admin</directory>
+      <directory suffix=".php">includes</directory>
+      <directory suffix=".php">public</directory>
+      <file>decker.php</file>
+      <file>uninstall.php</file>
+    </include>
+    <exclude>
+      <!-- Third party: copied in from vendor/erseco/mime-mail-parser by Composer -->
+      <directory>admin/vendor</directory>
+    </exclude>
+  </coverage>
   <php>
     <env name="WORDPRESS_TABLE_PREFIX" value="wp_"/>
   </php>


### PR DESCRIPTION
Brings the Codecov setup already used in `wp-exelearning` and `wp-autofirma` over to Decker.

## Why

CI ran the tests but measured nothing:

- `phpunit.xml.dist` had **no `<coverage>` section**, so PHPUnit had no scope to report on.
- wp-env started **without Xdebug**, so no coverage driver was available anyway.
- The **Jest suite never ran in CI** — 11 files, 93 tests, only ever run by hand.
- Nothing was published anywhere, and there was no `codecov.yml` and no badge.

## What changes

**PHP**
- `phpunit.xml.dist`: coverage scope over `admin/`, `includes/`, `public/`, `decker.php`, `uninstall.php`; `admin/vendor/` excluded, since Composer copies it in from `erseco/mime-mail-parser`.
- New `make test-coverage`: writes `clover.xml`, a text summary and an HTML report into `artifacts/coverage/`.
- `make up` now takes `WP_ENV_FLAGS`, so CI starts the environment with `--xdebug=coverage` without duplicating the target's logic. Local use is unchanged.

**JavaScript**
- Jest writes LCOV to `artifacts/coverage-js/`, and CI runs the suite (it did not before).
- `collectCoverageFrom` is deliberately **not** set. Nine of the eleven suites read their source with `fs.readFileSync` and evaluate it by hand, which Jest cannot instrument — a glob over `public/assets/js/**` would report those files as 0% covered while their tests pass. Only the two files loaded through `require()` are measured today: `agent-semantics.js` and `sidebar-preferences.js`, at **92.68%**. Converting the readFileSync suites to `require()` is what widens that number, and it belongs in its own PR.

**Codecov**
- Both reports upload under separate flags (`php`, `javascript`), authenticated with **OIDC** — no `CODECOV_TOKEN` secret to create or rotate.
- `codecov.yml`: statuses are `informational` (they comment, they don't block), and a path fix maps Clover's container paths back onto the repository. PHPUnit runs inside wp-env, so it records `/var/www/html/wp-content/plugins/decker/…`; without the fix Codecov cannot match a single file.
- `disable_search: true`, so the uploader does not also grab `coverage.txt`, the human-readable summary it cannot parse.

**Packaging bug found on the way**
`composer archive` does not read `.gitignore`, so everything under `artifacts/` was being packaged into the release ZIP. Verified against the current tree: without the fix the archive contains 13 `artifacts/coverage-js/…` entries, and it would be far more once the PHP HTML report (one page per source file) exists. `artifacts/` is now `export-ignore`d in `.gitattributes` and listed in `.distignore`.

## Verification

- `npx jest --coverage` — 11 suites, 93 tests pass; LCOV written with repository-relative paths.
- `codecov.yml` accepted by `https://codecov.io/validate`.
- Workflow, `codecov.yml`, `phpunit.xml.dist`, `jest.config.js` and `package.json` all parse.
- `composer archive` on this branch: 156 files, no `artifacts/`, no `codecov.yml`.

PHP coverage was not run locally on purpose — it would restart the shared wp-env into coverage mode. The CI run on this PR is what proves that path, same as it did in exelearning/wp-exelearning#83.

The repository is known to Codecov but not yet activated (`"activated": false`); the first successful upload from this PR is what turns it on, and the README badge stays blank until then.