### PR TITLE
Potential fix for code scanning alert no. 191: DOM text reinterpreted as HTML

### DIFF
--- a/public/assets/js/task-modal.js
+++ b/public/assets/js/task-modal.js
@@ -2,6 +2,43 @@ document.addEventListener('DOMContentLoaded', function () {
     const modalElement = document.getElementById('task-modal');
 
     /**
+     * Return a task ID as a decimal string without numeric coercion.
+     *
+     * @param {number|string} taskId The task ID to validate.
+     * @return {string|null} The validated task ID, or null when invalid.
+     */
+    function normalizeTaskId(taskId) {
+        const value = String(taskId);
+        return /^(0|[1-9]\d*)$/.test(value) ? value : null;
+    }
+
+    /**
+     * Render the task modal title without interpreting task data as HTML.
+     *
+     * @param {jQuery} modalTitle The jQuery-wrapped title element.
+     * @param {number|string} taskId The task ID to render.
+     */
+    function renderTaskModalTitle(modalTitle, taskId) {
+        const safeTaskId = normalizeTaskId(taskId);
+        if (!safeTaskId || safeTaskId === '0') {
+            modalTitle.text('Task');
+            return;
+        }
+
+        const permalink = deckerVars.taskPermalinkStructure.replace('%d', safeTaskId);
+
+        modalTitle.empty();
+        modalTitle.append(document.createTextNode(`Task #${safeTaskId} `));
+        const copyLink = jQuery('<a></a>')
+            .attr('href', '#')
+            .addClass('copy-task-url')
+            .attr('data-task-url', permalink)
+            .attr('title', deckerVars.strings.copy_task_url)
+            .append(jQuery('<i></i>').addClass('ri-clipboard-line'));
+        modalTitle.append(copyLink);
+    }
+
+    /**
      * Fetch the task card markup and (re)initialize it inside the modal body.
      *
      * @param {jQuery} modal  The jQuery-wrapped modal element.
@@ -27,22 +64,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 modal.find('#task-modal-body').html(data);
 
                 const modalTitle = modal.find('#NewTaskModalLabel');
-                if (taskId && taskId != 0) {
-                    const safeTaskId = String(parseInt(taskId, 10));
-                    const permalink = deckerVars.taskPermalinkStructure.replace('%d', safeTaskId);
-
-                    modalTitle.empty();
-                    modalTitle.append(document.createTextNode(`Task #${safeTaskId} `));
-                    const copyLink = jQuery('<a></a>')
-                        .attr('href', '#')
-                        .addClass('copy-task-url')
-                        .attr('data-task-url', permalink)
-                        .attr('title', deckerVars.strings.copy_task_url)
-                        .append(jQuery('<i></i>').addClass('ri-clipboard-line'));
-                    modalTitle.append(copyLink);
-                } else {
-                    modalTitle.text('Task');
-                }
+                renderTaskModalTitle(modalTitle, taskId);
 
                // After loading the content, initialize the JS functions
                 if (typeof window.initializeSendComments === 'function' && typeof window.initializeTaskPage === 'function') {

--- a/public/assets/js/task-modal.js
+++ b/public/assets/js/task-modal.js
@@ -28,9 +28,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
                 const modalTitle = modal.find('#NewTaskModalLabel');
                 if (taskId && taskId != 0) {
-                    const permalink = deckerVars.taskPermalinkStructure.replace('%d', taskId);
-                    const newTitle = `Task #${taskId} <a href="#" class="copy-task-url" data-task-url="${permalink}" title="${deckerVars.strings.copy_task_url}"><i class="ri-clipboard-line"></i></a>`;
-                    modalTitle.html(newTitle);
+                    const safeTaskId = String(parseInt(taskId, 10));
+                    const permalink = deckerVars.taskPermalinkStructure.replace('%d', safeTaskId);
+
+                    modalTitle.empty();
+                    modalTitle.append(document.createTextNode(`Task #${safeTaskId} `));
+                    const copyLink = jQuery('<a></a>')
+                        .attr('href', '#')
+                        .addClass('copy-task-url')
+                        .attr('data-task-url', permalink)
+                        .attr('title', deckerVars.strings.copy_task_url)
+                        .append(jQuery('<i></i>').addClass('ri-clipboard-line'));
+                    modalTitle.append(copyLink);
                 } else {
                     modalTitle.text('Task');
                 }

--- a/tests/js/task-modal.test.js
+++ b/tests/js/task-modal.test.js
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for safe task modal title rendering.
+ *
+ * @package Decker
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const source = fs.readFileSync(
+	path.join( __dirname, '../../public/assets/js/task-modal.js' ),
+	'utf8'
+);
+
+function extractFunctionSource( functionName ) {
+	const start = source.indexOf( `function ${ functionName }` );
+	if ( start === -1 ) {
+		throw new Error( `Function ${ functionName } not found` );
+	}
+
+	const bodyStart = source.indexOf( '{', start );
+	let depth = 0;
+
+	for ( let position = bodyStart; position < source.length; position++ ) {
+		const char = source[ position ];
+		if ( char === '{' ) {
+			depth++;
+		} else if ( char === '}' ) {
+			depth--;
+			if ( depth === 0 ) {
+				return source.slice( start, position + 1 );
+			}
+		}
+	}
+
+	throw new Error( `Function ${ functionName } has no closing brace` );
+}
+
+function instantiate( functionName, scope ) {
+	const keys = Object.keys( scope );
+	const values = keys.map( ( key ) => scope[ key ] );
+	const functionSource = extractFunctionSource( functionName );
+	return new Function( ...keys, `return (${ functionSource });` )( ...values );
+}
+
+function wrapElement( element ) {
+	const wrapper = {
+		element,
+		empty() {
+			element.replaceChildren();
+			return wrapper;
+		},
+		append( child ) {
+			element.appendChild( child.element || child );
+			return wrapper;
+		},
+		text( value ) {
+			element.textContent = value;
+			return wrapper;
+		},
+		attr( name, value ) {
+			element.setAttribute( name, value );
+			return wrapper;
+		},
+		addClass( className ) {
+			element.classList.add( className );
+			return wrapper;
+		},
+	};
+
+	return wrapper;
+}
+
+function jQueryStub( markup ) {
+	const match = /^<([a-z]+)><\/\1>$/.exec( markup );
+	if ( ! match ) {
+		throw new Error( `Unsupported jQuery markup: ${ markup }` );
+	}
+
+	return wrapElement( document.createElement( match[ 1 ] ) );
+}
+
+describe( 'renderTaskModalTitle', () => {
+	let modalTitle;
+	let renderTaskModalTitle;
+
+	beforeEach( () => {
+		document.body.innerHTML = '<h5 id="task-title"></h5>';
+		modalTitle = document.getElementById( 'task-title' );
+
+		const normalizeTaskId = instantiate( 'normalizeTaskId', {} );
+		renderTaskModalTitle = instantiate( 'renderTaskModalTitle', {
+			normalizeTaskId,
+			deckerVars: {
+				taskPermalinkStructure: 'https://example.com/tasks/%d',
+				strings: {
+					copy_task_url: 'Copy task URL',
+				},
+			},
+			jQuery: jQueryStub,
+			document,
+		} );
+	} );
+
+	test( 'renders a normal task ID and the expected permalink', () => {
+		renderTaskModalTitle( wrapElement( modalTitle ), '123' );
+
+		expect( modalTitle.firstChild.nodeValue ).toBe( 'Task #123 ' );
+		const copyLink = modalTitle.querySelector( 'a.copy-task-url' );
+		expect( copyLink ).not.toBeNull();
+		expect( copyLink.getAttribute( 'href' ) ).toBe( '#' );
+		expect( copyLink.dataset.taskUrl ).toBe( 'https://example.com/tasks/123' );
+		expect( copyLink.getAttribute( 'title' ) ).toBe( 'Copy task URL' );
+		expect( copyLink.querySelector( 'i.ri-clipboard-line' ) ).not.toBeNull();
+	} );
+
+	test( 'rejects HTML-like task IDs without creating injected elements', () => {
+		renderTaskModalTitle(
+			wrapElement( modalTitle ),
+			'123"><img src=x onerror=alert(1)>'
+		);
+
+		expect( modalTitle.textContent ).toBe( 'Task' );
+		expect( modalTitle.querySelector( 'a' ) ).toBeNull();
+		expect( modalTitle.querySelector( 'img' ) ).toBeNull();
+	} );
+
+	test( 'preserves task IDs beyond the JavaScript safe integer range', () => {
+		const largeTaskId = '9007199254740993';
+		renderTaskModalTitle( wrapElement( modalTitle ), largeTaskId );
+
+		expect( modalTitle.firstChild.nodeValue ).toBe( `Task #${ largeTaskId } ` );
+		expect( modalTitle.querySelector( 'a' ).dataset.taskUrl )
+			.toBe( `https://example.com/tasks/${ largeTaskId }` );
+	} );
+} );


### PR DESCRIPTION
Potential fix for [https://github.com/ateeducacion/wp-decker/security/code-scanning/191](https://github.com/ateeducacion/wp-decker/security/code-scanning/191)

General fix: never pass tainted/interpolated strings to `.html()`. Use `.text()` for text content and create DOM elements via jQuery/DOM APIs, setting attributes/text with safe setters.

Best fix in `public/assets/js/task-modal.js` around the `loadTaskCard` success handler (lines ~29–35): replace `newTitle` string + `modalTitle.html(newTitle)` with:
1. `modalTitle.empty()`
2. append plain text `Task #${safeTaskId}`
3. append a programmatically created `<a>` and `<i>` with `.attr(...)` for attributes.
4. coerce `taskId` to a safe integer-like string before display/URL substitution.

No changes are required in `task-card.js` for this sink fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
