### PR TITLE
Package the release ZIP with wp dist-archive

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,70 +1,87 @@
-# Directories
-.agents
-.claude
-.git
-.github
-.idea
-.wordpress-org
-artifacts
-bin
-build
-build-cs
-build-phpunit
-docs
-node_modules
-patches
-# Distributed via vendor/plugin-check/phpcs-sniffs instead
-/phpcs-sniffs/
-tests
-vendor
-wp-content
+# Files and directories kept out of the release ZIP.
+#
+# This is the single source of truth for what ships. `make package` builds the
+# archive with `wp dist-archive`, which reads this file straight from the working
+# tree, so the generated runtime translations that .gitignore keeps out of the
+# repository are packaged like any other file.
+#
+# `.gitattributes` does NOT feed this archive. It only shapes the source ZIP that
+# GitHub serves at archive/refs/heads/*.zip, the one blueprint.json installs in
+# WordPress Playground.
+#
+# Two matching rules to keep in mind, both inherited from
+# inmarelibero/gitignore-checker:
+#
+#   * Matching is case-insensitive, unlike git on Linux.
+#   * An unanchored rule matches at any depth. A bare `vendor` rule would strip
+#     admin/vendor/mime-mail-parser, which the plugin loads at runtime from
+#     includes/class-decker-email-to-post.php.
+#
+# Root-only rules therefore carry a leading slash. The few rules that must match
+# at any depth are grouped at the end.
 
-# Language stuff
-languages/*.pot
+# CI
+/.github
+/.gitlab-ci.yml
+
+# Agent instructions and vendored skills
+/.agents
+/.claude
+/.superpowers
+/AGENTS.md
+/CLAUDE.md
+/skills-lock.json
+
+# Development tooling and configuration
+/.editorconfig
+/.phpcs.xml.dist
+/.phpunit.result.cache
+/.stylelintrc
+/.wp-env.json
+/codecov.yml
+/composer.json
+/composer.lock
+/jest.config.js
+/Makefile
+/package.json
+/package-lock.json
+/phpunit.xml.dist
+/renovate.json
+
+# Tests and everything they write
+/artifacts
+/private
+/tests
+
+# Development dependencies. Only the root vendor/ is excluded: the runtime
+# libraries live in admin/vendor/, copied there by composer's post-install-cmd.
+/node_modules
+/vendor
+
+# Repository documentation. readme.txt is the user-facing one and does ship.
+/blueprint.json
+/CODE_OF_CONDUCT.md
+/CONVENTIONS.md
+/docs
+/README.md
+/SECURITY.md
+
+# Translation sources. Only the runtime files ship: .l10n.php (WordPress 6.5+),
+# .mo (fallback for 6.1-6.4) and the JS .json files. Both rules contain a slash,
+# which already anchors them to the root.
 languages/*.po
+languages/*.pot
 
-# Files
-.aider.chat.history.md
-.aider.input.history
-AGENTS.md
-CLAUDE.md
-skills-lock.json
-*.DS_Store
+# The packaging metadata itself
+/.distignore
+/.gitattributes
+/.gitignore
+
+# Rules that must match at any depth: none of these is ever legitimate inside a
+# release, wherever it turns up.
+.git
+node_modules
 .DS_Store
-.distignore
-.editorconfig
-.eslintrc.js
-.gherkin-lintignore
-.gherkin-lintrc
-.gitattributes
-.gitignore
-.nvmrc
-.php-cs-fixer.php
-.phpunit.result.cache
-.stylelintrc
-.typos.toml
-.wp-env.json
-.wp-env.override.json
-behat.yml
-codecov.yml
-CODE_OF_CONDUCT.md
-composer.json
-composer.lock
-CONVENTIONS.md
-CONTRIBUTING.md
-docker-compose.yml
-Makefile
-package.json
-package-lock.json
-phpcs.xml
-phpcs.xml.dist
-phpmd.xml
-phpstan.neon
-phpstan.neon.dist
-phpunit.xml
-phpunit.xml.dist
-plugin-check.iml
-README.md
-renovate.json
-SECURITY.md
+*.DS_Store
+.idea
 sftp-config.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,42 +1,15 @@
-# Exclude hidden files and directories
-.*                         export-ignore
-
-# Exclude .po and .pot language files
-languages/*.po             export-ignore
-languages/*.pot            export-ignore
-
-# Exclude development files
-*.css.map 				   export-ignore
-/vendor/                   export-ignore
-# Test and coverage output. `composer archive` does not read .gitignore, so
-# without this the reports written by `make test-coverage` and the Playwright
-# runs would travel inside the release ZIP.
-artifacts/                 export-ignore
-# Agent instructions and skills. `.agents/` and `.claude/` already match the
-# `.*` rule above; these three do not, and a plugin ZIP has no use for them.
-AGENTS.md                  export-ignore
-CLAUDE.md                  export-ignore
-skills-lock.json           export-ignore
-blueprint.json             export-ignore
-codecov.yml                export-ignore
-CHANGELOG.md               export-ignore
-CODE_OF_CONDUCT.md         export-ignore
-composer.json              export-ignore
-composer.lock              export-ignore
-CONVENTIONS.md             export-ignore
-docker-compose.yml         export-ignore
-docs/                      export-ignore
-Makefile                   export-ignore
-mkdocs.yml                 export-ignore
-node_modules/              export-ignore
-package-lock.json          export-ignore
-package.json               export-ignore
-phpunit.xml.dist           export-ignore
-phpunit.xml.dist           export-ignore
-README.md                  export-ignore
-README.md                  export-ignore
-renovate.json              export-ignore
-sftp-config.json           export-ignore
-sonar-project.properties   export-ignore
-test.php                   export-ignore
-tests/                     export-ignore
+# Nothing here feeds the release ZIP. That archive is built by `wp dist-archive`
+# and its exclusion list is .distignore, the single source of truth for what
+# ships.
+#
+# These rules only shape the source ZIP that GitHub serves at
+# archive/refs/heads/*.zip, the one blueprint.json installs in WordPress
+# Playground. Keep the list short and do not mirror .distignore into it: paths
+# git does not track (node_modules/, vendor/, artifacts/) never reach a git
+# archive in the first place.
+/.agents        export-ignore
+/.claude        export-ignore
+/.github        export-ignore
+/.gitattributes export-ignore
+/docs           export-ignore
+/tests          export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,28 @@
-# Nothing here feeds the release ZIP. That archive is built by `wp dist-archive`
+# Line endings are deliberately NOT normalised repo-wide here. Adding
+# `* text=auto eol=lf` would rewrite public/assets/js/app.js, which has mixed
+# endings (711 CR lines) and ships in the release ZIP; that belongs in its own
+# change, not in a packaging one.
+#
+# The two rules below are protective on their own: `-text` stops git from
+# re-encoding these files whatever the contributor's core.autocrlf is set to.
+
+# The .eml fixtures are real messages captured from Gmail, Zimbra and Nextcloud.
+# On the wire a mail line ends in CRLF (RFC 5322 §2.1), and that is the form the
+# parser meets in production, so these files are kept byte-for-byte as captured.
+#
+# Converting them to LF would not fail anything, which is exactly why it is a
+# trap: parsing all eleven fixtures with LF endings yields identical subjects,
+# headers and part checksums, so the suite would stay green while quietly losing
+# its only coverage of the real wire format. The inline fixtures in
+# tests/unit/includes/DeckerEmailToPostTest.php build their messages with
+# explicit "\r\n" for the same reason.
+tests/fixtures/*.eml -text
+
+# Vendored third party, copied verbatim from upstream by composer's
+# post-install-cmd. Never re-encode it.
+admin/vendor/** -text
+
+# Nothing below feeds the release ZIP. That archive is built by `wp dist-archive`
 # and its exclusion list is .distignore, the single source of truth for what
 # ships.
 #

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,10 @@ package: package-translations
 	@# --plugin-dirname is what makes the archive extract as decker/. Without it
 	@# WordPress names the plugin folder after the ZIP file and every release
 	@# lands in a new directory.
+	@# `--force` does not empty an existing archive: dist-archive 3.1 shells out
+	@# to the `zip` binary, which ADDS to one. Without this removal a file that a
+	@# new .distignore rule excludes would survive from an earlier build.
+	rm -f "$(CURDIR)/decker-$(VERSION).zip"
 	./vendor/bin/wp dist-archive . "$(CURDIR)/decker-$(VERSION).zip" \
 		--plugin-dirname=decker --force
 

--- a/Makefile
+++ b/Makefile
@@ -300,8 +300,15 @@ package: package-translations
 	$(SED_INPLACE) "s/define( 'DECKER_VERSION', '[^']*'/define( 'DECKER_VERSION', '$(VERSION)'/" decker.php
 	$(SED_INPLACE) "s/^Stable tag:.*/Stable tag: $(VERSION)/" readme.txt
 
-	# Create the ZIP package
-	composer archive --format=zip --file="decker-$(VERSION)"
+	@# Create the ZIP package with proper folder structure.
+	@# `wp dist-archive` reads .distignore straight from the working tree, so the
+	@# runtime translations that .gitignore keeps out of the repository are
+	@# packaged like any other file.
+	@# --plugin-dirname is what makes the archive extract as decker/. Without it
+	@# WordPress names the plugin folder after the ZIP file and every release
+	@# lands in a new directory.
+	./vendor/bin/wp dist-archive . "$(CURDIR)/decker-$(VERSION).zip" \
+		--plugin-dirname=decker --force
 
 	# Restore the version in decker.php & readme.txt
 	$(SED_INPLACE) "s/^ \* Version:.*/ * Version:           0.0.0/" decker.php

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "phpcompatibility/phpcompatibility-wp": "*",
         "phpunit/phpunit": "*",
         "squizlabs/php_codesniffer": "*",
+        "wp-cli/dist-archive-command": "^3.1",
         "wp-cli/i18n-command": "*",
         "wp-coding-standards/wpcs": "*",
         "yoast/phpunit-polyfills": "*",


### PR DESCRIPTION
## The bug this fixes

The release ZIP had **no top-level directory**. `composer archive` never adds a path prefix, so WordPress fell back to naming the plugin folder after the ZIP file:

```php
// wp-admin/includes/class-wp-upgrader.php:640-643 — WP_PLUGIN_DIR is a protected directory
$destination = trailingslashit( $destination ) . trailingslashit( basename( $source ) );
```

with `$source` being the working directory, named at `:378` from the package filename. So `decker-1.2.3.zip` installed into `wp-content/plugins/decker-1.2.3/`. Every release lands in a **new folder**, WordPress treats it as a different plugin, deactivates the previous one and leaves the old copy on disk.

`wp dist-archive --plugin-dirname=decker` produces a single `decker/` directory, whatever the ZIP is called.

## The second problem

**Nothing read `.distignore`.** The list that actually applied was `.gitattributes`, which is why `jest.config.js` and `SECURITY.md` shipped even though `.distignore` excludes both. The good list was the dead one.

## What changed

- **`Makefile`** — `composer archive` → `./vendor/bin/wp dist-archive . decker-$(VERSION).zip --plugin-dirname=decker --force`.
- **`composer.json`** — `wp-cli/dist-archive-command: ^3.1` in `require-dev`. The pin matters: 3.2+ needs `wp-cli ^2.13`, which has no stable release; 3.1.0 shells out to the `zip` binary so no `ext-zip` is required. The release workflow already runs `composer install` before `make package`, so nothing there needs changing.
- **`.distignore`** — becomes the real list. Pruned of ~29 rules inherited from `WordPress/plugin-check` that match nothing here (`plugin-check.iml`, `behat.yml`, `.gherkin-lintrc`, `phpstan.neon`, `/phpcs-sniffs/`…), and extended with paths only `.gitattributes` covered: `.gitlab-ci.yml`, `.phpcs.xml.dist`, `blueprint.json`, `jest.config.js` — plus `.superpowers/` and `private/`, which are untracked but sit in the working tree `dist-archive` reads.
- **`.gitattributes`** — 32 rules → 6, with a header saying it does not feed the release.

## One trap worth flagging

Matching in `wp dist-archive` is case-insensitive and **unanchored rules match at any depth**. The `vendor` rule `.distignore` used to carry would have stripped `admin/vendor/mime-mail-parser` — the library `includes/class-decker-email-to-post.php:237` loads at runtime — and shipped a broken plugin. Every root-only rule now carries a leading slash.

I also did **not** add `* text=auto eol=lf` to `.gitattributes`: `tests/fixtures/*.eml` are committed with CRLF on purpose, and normalising them would break the mail parser tests.

## Verification

Built the ZIP before and after and diffed the file lists (the rest of the diff is directory entries, which `dist-archive` records and `composer archive` did not):

```
< jest.config.js
< SECURITY.md
> admin/vendor/mime-mail-parser/composer.json
```

The vendored library now travels intact — the previous unanchored `composer.json` rule was clipping it. Root of the new ZIP:

```
decker/decker.php
decker/LICENSE.txt
decker/readme.txt
decker/uninstall.php
```

## Heads-up, unrelated to this PR

`sftp-config.json` sits untracked in the working tree with `host`, `user` and `password` keys. It is excluded from the ZIP (and stays excluded here), but it is worth adding to `.gitignore` so it cannot be committed by accident.

## Context

Second of four PRs unifying packaging across `wp-exelearning`, `wp-decker`, `wp-documentate` and `wp-autofirma`. The design is in wp-exelearning's [SDD-0002](https://github.com/exelearning/wp-exelearning/pull/86) and the decision in ADR-0003.


---

## Añadido: los fixtures `.eml` quedan fijados, no convertidos

Se planteó aprovechar para pasarlos a LF. **La medición dice que no conviene**: parseando los once fixtures con finales LF salen idénticos el asunto, las cabeceras y los checksums de cada parte. Es decir, la conversión pasaría los tests sin que nadie lo notase, y a cambio se perdería la única cobertura del formato que llega de verdad por el cable — CRLF, RFC 5322 §2.1 — que es lo que envían Gmail, Zimbra y Nextcloud, de donde están capturados. Los fixtures que los tests construyen en línea ya usan `\r\n` explícito por el mismo motivo.

Así que se fijan con `-text`, que impide a git reconvertirlos sea cual sea el `core.autocrlf` de quien contribuya. Lo mismo para `admin/vendor/`, copiado tal cual de upstream.

**No se añade `* text=auto eol=lf`**: reescribiría `public/assets/js/app.js`, que tiene finales mezclados (711 líneas con CR) y viaja en el ZIP. Eso merece su propia PR. Comprobado con `git add --renormalize .`, que ya no reporta ningún fichero salvo el propio `.gitattributes`.

**`rm -f` antes de archivar**, porque `--force` no vacía el ZIP anterior.
